### PR TITLE
Fix safe_backfill

### DIFF
--- a/nntmux/libraries/Forking.php
+++ b/nntmux/libraries/Forking.php
@@ -241,6 +241,7 @@ class Forking extends \fork_daemon
 	private function processStartWork()
 	{
 		switch ($this->workType) {
+			case 'safe_backfill':
 			case 'safe_binaries':
 				$this->_executeCommand(
 					PHP_BINARY . ' ' . NN_NIX . 'tmux/bin/update_groups.php'


### PR DESCRIPTION
Changes made by this pull request.
- Added case back to processStartWork which reverts part of 5a7fc8387c15af5641eec103122a2c807dc07f98