### PR TITLE
Display SABnzbd Integration on profile page for all themes

### DIFF
--- a/www/themes/Charisma/templates/profile.tpl
+++ b/www/themes/Charisma/templates/profile.tpl
@@ -122,6 +122,18 @@
 																<th>Downloads Total</th>
 																<td>{$user.grabs}</td>
 															</tr>
+															{if $site->sabintegrationtype == 2 && !$publicview}
+																<tr>
+																	<th>SABnzbd Integration:</th>
+																	<td>
+																		<b>Url:</b> {if $saburl == ''}N/A{else}{$saburl}{/if}<br/>
+																		<b>Key:</b> {if $sabapikey == ''}N/A{else}{$sabapikey}{/if}<br/>
+																		<b>Type:</b> {if $sabapikeytype == ''}N/A{else}{$sabapikeytype}{/if}<br/>
+																		<b>Priority:</b> {if $sabpriority == ''}N/A{else}{$sabpriority}{/if}<br/>
+																		<b>Storage:</b> {if $sabsetting == ''}N/A{else}{$sabsetting}{/if}
+																	</td>
+																</tr>
+															{/if}
 															{if isset($isadmin) || !$publicview}
 																<tr>
 																	<th title="Not public">API/RSS Key</th>

--- a/www/themes/Gentele/templates/profile.tpl
+++ b/www/themes/Gentele/templates/profile.tpl
@@ -131,6 +131,18 @@
 															<th>Downloads Total</th>
 															<td>{$user.grabs}</td>
 														</tr>
+														{if $site->sabintegrationtype == 2 && !$publicview}
+															<tr>
+																<th>SABnzbd Integration:</th>
+																<td>
+																	<b>Url:</b> {if $saburl == ''}N/A{else}{$saburl}{/if}<br/>
+																	<b>Key:</b> {if $sabapikey == ''}N/A{else}{$sabapikey}{/if}<br/>
+																	<b>Type:</b> {if $sabapikeytype == ''}N/A{else}{$sabapikeytype}{/if}<br/>
+																	<b>Priority:</b> {if $sabpriority == ''}N/A{else}{$sabpriority}{/if}<br/>
+																	<b>Storage:</b> {if $sabsetting == ''}N/A{else}{$sabsetting}{/if}
+																</td>
+															</tr>
+														{/if}
 														{if isset($isadmin) || !$publicview}
 															<tr>
 																<th title="Not public">API/RSS Key</th>

--- a/www/themes/Omicron/templates/profile.tpl
+++ b/www/themes/Omicron/templates/profile.tpl
@@ -122,6 +122,18 @@
 																<th>Downloads Total</th>
 																<td>{$user.grabs}</td>
 															</tr>
+															{if $site->sabintegrationtype == 2 && !$publicview}
+																<tr>
+																	<th>SABnzbd Integration:</th>
+																	<td>
+																		<b>Url:</b> {if $saburl == ''}N/A{else}{$saburl}{/if}<br/>
+																		<b>Key:</b> {if $sabapikey == ''}N/A{else}{$sabapikey}{/if}<br/>
+																		<b>Type:</b> {if $sabapikeytype == ''}N/A{else}{$sabapikeytype}{/if}<br/>
+																		<b>Priority:</b> {if $sabpriority == ''}N/A{else}{$sabpriority}{/if}<br/>
+																		<b>Storage:</b> {if $sabsetting == ''}N/A{else}{$sabsetting}{/if}
+																	</td>
+																</tr>
+															{/if}
 															{if isset($isadmin) || !$publicview}
 																<tr>
 																	<th title="Not public">API/RSS Key</th>


### PR DESCRIPTION
As per the title, only the Gamma theme has this functionality originally.
This has now been included for all other themes.