### PR TITLE
Use new getAllEpisodes function in TVDB library

### DIFF
--- a/Blacklight/processing/tv/TVDB.php
+++ b/Blacklight/processing/tv/TVDB.php
@@ -341,7 +341,7 @@ class TVDB extends TV
             }
         } elseif ($videoId > 0) {
             try {
-                $response = $this->client->series()->getEpisodes($tvDbId)->getData();
+                $response = $this->client->series()->getAllEpisodes($tvDbId);
             } catch (ResourceNotFoundException $error) {
                 return false;
             }


### PR DESCRIPTION
Fixes TVDB only returning 100 rows. Need to run composer update to grab latest TVDB lib (1.2.3)