### PR TITLE
Update predb_import_daily_batch.php

### DIFF
--- a/cli/data/predb_import_daily_batch.php
+++ b/cli/data/predb_import_daily_batch.php
@@ -86,7 +86,7 @@ foreach ($data as $dir => $files) {
     foreach ($files as $file) {
         if (preg_match("#^https://raw\.githubusercontent\.com/nZEDb/nZEDbPre_Dumps/master/dumps/$dir/$filePattern$#", $file['download_url'])) {
             if (preg_match("#^$filePattern$#", $file['name'], $match)) {
-                $timematch = $progress['last'];
+                $timematch = max($progress['last'], $argv[1]);
 
                 // Skip patches the user does not want.
                 if ($match[1] < $timematch) {


### PR DESCRIPTION
Fix a case where the progress input value is ignored:
1. php predb_import_daily_batch.php 0 local true
2. Ctrl-C after a few inserts

When you run the command php predb_import_daily_batch.php 1577874008 local true, it will not start from 1577874008 but from where it was when you pressed Ctrl-C. If this is desired behavior, please discard the pull request.