### PR TITLE
added -y so upgrade happens automatically instead of aborting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -q update && \
-    apt-get -q upgrade && \
+    apt-get -qy upgrade && \
     apt-get install -qy screen time sudo unzip software-properties-common nano git make automake build-essential pkg-config libevent-dev libncurses5-dev fonts-powerline powerline mariadb-client libmysqlclient-dev unrar p7zip-full mediainfo lame ffmpeg && \
     add-apt-repository ppa:ondrej/php && \
     apt-get -q update && \


### PR DESCRIPTION
Building the container kept aborting during the upgrade since it was asking for confirmation but never got it, so it would die.

> root@newznab:/home/bran/newznab-tmux# /snap/bin/docker-compose run --rm nn-tmux sh /tmp/install.sh
> Starting newznab-tmux_redis_1     ... done
> Starting newznab-tmux_manticore_1 ... done
> Starting newznab-tmux_mariadb_1   ... done
> Building nn-tmux
> Step 1/25 : FROM ubuntu:18.04
>  ---> c3c304cb4f22
> Step 2/25 : ENV DEBIAN_FRONTEND=noninteractive
>  ---> Using cache
>  ---> 009eae0e033d
> Step 3/25 : RUN apt-get -q update &&     apt-get -q upgrade &&     apt-get install -qy screen time sudo unzip software-properties-common nano git make automake build-essential pkg-config libevent-dev libncurses5-dev fonts-powerline powerline mariadb-client libmysqlclient-dev unrar p7zip-full mediainfo lame ffmpeg &&     add-apt-repository ppa:ondrej/php &&     apt-get -q update &&     apt-get install -qy apache2 libapache2-mod-php7.3 php-pear php7.3 php7.3-cli php7.3-dev php7.3-common php7.3-curl php7.3-json php7.3-gd php7.3-mysql php7.3-mbstring php7.3-xml php7.3-intl php7.3-fpm php7.3-bcmath php7.3-zip php-imagick
>  ---> Running in 602703966ab5
> ...
> Fetched 18.0 MB in 5s (3888 kB/s)
> Reading package lists...
> Reading package lists...
> Building dependency tree...
> Reading state information...
> Calculating upgrade...
> The following packages will be upgraded:
>   apt libapt-pkg5.0 libsystemd0 libudev1
> 4 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
> Need to get 2272 kB of archives.
> After this operation, 3072 B of additional disk space will be used.
> Do you want to continue? [Y/n] Abort.
> ERROR: Service 'nn-tmux' failed to build: The command '/bin/sh -c apt-get -q update &&     apt-get -q upgrade &&     apt-get install -qy screen time sudo unzip software-properties-common nano git make automake build-essential pkg-config libevent-dev libncurses5-dev fonts-powerline powerline mariadb-client libmysqlclient-dev unrar p7zip-full mediainfo lame ffmpeg &&     add-apt-repository ppa:ondrej/php &&     apt-get -q update &&     apt-get install -qy apache2 libapache2-mod-php7.3 php-pear php7.3 php7.3-cli php7.3-dev php7.3-common php7.3-curl php7.3-json php7.3-gd php7.3-mysql php7.3-mbstring php7.3-xml php7.3-intl php7.3-fpm php7.3-bcmath php7.3-zip php-imagick' returned a non-zero code: 1