### PR TITLE
Escape Message-ID during update binaries

### DIFF
--- a/Blacklight/Binaries.php
+++ b/Blacklight/Binaries.php
@@ -895,6 +895,9 @@ class Binaries
                 $binariesUpdate[$binaryID]['Parts']++;
             }
 
+            // In case there are quotes in the message id
+            $this->header['Message-ID'] = addslashes($this->header['Message-ID']);
+
             // Strip the < and >, saves space in DB.
             $this->header['Message-ID'][0] = "'";
 


### PR DESCRIPTION
I ran misc/update/update_binaries.php manually because I noticed a lot
of missing parts that weren't going away and noticed sql errors on the
INSERT IGNORE. It turns out that some of the message IDs had single
quotes in them that inhibited the query from executing properly.

An example I found is: 200420092300004385%But-i-really@dont'care.com
(oddly enough, the single quote isn't in the word don't, but after...)

semi-sanitizing the data through the `addslashes` function takes care of
the problem -- I'm not aware if there's a more elegant method of
sanitizing that is available. Please let me know if there is and I'll
update.