### PR TITLE
Memory workarounds for categorize.php

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ before_script:
      - echo 'memory_limit = 1024M' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
      # Set permissions, can't use newgrp with travis so we need to do it this way.
      - sudo chmod -R 777 /home/travis/
+     - mkdir tests/Unit
 
 
 script:

--- a/cli/recategorize-range.sh
+++ b/cli/recategorize-range.sh
@@ -42,7 +42,7 @@ for batch in $(seq $start $stop); do
         php misc/testing/Releases/recategorize.php all notest $offset $batchSize
         if [[ $? != 27 ]]; then
             echo -e "${M}${offset}${D}"
-            exit
+            break
         else
             date
             sleep 3

--- a/cli/recategorize-range.sh
+++ b/cli/recategorize-range.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+D="\e[39m"
+G="\e[32m"
+M="\e[91m"
+
+if [[ ! $1 || ! $2 || ! $3 ]]; then
+    echo -e "${G}This script chunks calls to misc/testing/Releases/recategorize.php to work around memory issues."
+    echo -e "It also automatically retries when a chunk is halted due to low memory.${D}"
+    echo -e "${M}Three parameters are required:${D}"
+    echo "1. start position"
+    echo "2. stop position"
+    echo "3. batch size"
+    echo -e "${G}You can send shortened ints, i.e. 3m for 3000000 or 2.5k for 2500.${D}"
+    exit 1
+fi
+
+function toInt {
+    local multiplier=$([[ "$1" == *"m"* ]] && echo 1000000 || echo 1)
+    multiplier=$([[ "$1" == *"k"* ]] && echo 1000 || echo $multiplier)
+    local num=${1/[mk]/}
+    num=$(echo "$num * $multiplier" | bc)
+    num=${num%.*}
+
+    echo $num
+}
+
+start=$(toInt $1)
+stop=$(toInt $2)
+batchSize=$(toInt $3)
+
+echo "Expanded params: start $start, stop $stop, batchSize $batchSize"
+
+start=$(( start / batchSize ))
+stop=$(( stop / batchSize ))
+
+for batch in $(seq $start $stop); do
+    offset=$(( $batch * $batchSize ))
+
+    echo -e "${G}${offset}${D}"
+    while true; do
+        php misc/testing/Releases/recategorize.php all notest $offset $batchSize
+        if [[ $? != 27 ]]; then
+            echo -e "${M}${offset}${D}"
+            exit
+        else
+            date
+            sleep 3
+        fi
+    done
+done

--- a/misc/testing/Releases/recategorize.php
+++ b/misc/testing/Releases/recategorize.php
@@ -12,15 +12,17 @@ use Illuminate\Support\Facades\DB;
 $colorCli = new ColorCLI();
 
 if (! (isset($argv[1]) && ($argv[1] === 'all' || $argv[1] === 'misc' || preg_match('/\([\d, ]+\)/', $argv[1]) || is_numeric($argv[1])))) {
-    $colorCli->error(
-        "\nThis script will attempt to re-categorize releases and is useful if changes have been made to Category.php.\n"
-        ."No updates will be done unless the category changes\n"
-        ."An optional last argument, test, will display the number of category changes that would be made\n"
-        ."but will not update the database.\n\n"
-        ."php $argv[0] all                     ...: To process all releases.\n"
-        ."php $argv[0] misc                    ...: To process all releases in misc categories.\n"
-        ."php $argv[0] 155                     ...: To process all releases in groupid 155.\n"
-        ."php $argv[0] '(155, 140)'            ...: To process all releases in groupids 155 and 140.\n"
+    $colorCli->warning(PHP_EOL.'This script will attempt to re-categorize releases and is useful if changes have been made to Category.php.');
+    $colorCli->error(PHP_EOL
+        .'Argument 1: groups - (all, misc, groupid -- 155 or groupids "(155, 140)")'.PHP_EOL
+        .'Argument 2: (optional) test or notest - if test, will display the number of category changes that would be made but will not update the database'.PHP_EOL
+        .'Argument 3: (optional) offset - What starting release *number* to begin recategorizing. Releases are sorted by id DESC'.PHP_EOL
+        .'Argument 4: (optional) limit - How many releases to process before stopping'.PHP_EOL.PHP_EOL
+        .'php '.$argv[0].' all                     ...: To process all releases.'.PHP_EOL
+        .'php '.$argv[0].' misc                    ...: To process all releases in misc categories.'.PHP_EOL
+        .'php '.$argv[0].' 155                     ...: To process all releases in groupid 155.'.PHP_EOL
+        .'php '.$argv[0].' "(155, 140)"            ...: To process all releases in groupids 155 and 140.'.PHP_EOL
+        .'php '.$argv[0].' all notest 1000 100     ...: To process all releases from the most recent 1000th release. Stop after processing 100 releases'.PHP_EOL
     );
     exit();
 }
@@ -29,37 +31,41 @@ reCategorize($argv);
 
 function reCategorize($argv)
 {
+    [$path, $groups, $test, $offset, $limit] = array_pad($argv, 5, null);
     $colorCli = new ColorCLI();
     $where = '';
     $otherCats = implode(',', Category::OTHERS_GROUP);
     $update = true;
-    if (isset($argv[1]) && is_numeric($argv[1])) {
-        $where = ' AND groups_id = '.$argv[1];
-    } elseif (isset($argv[1]) && preg_match('/\([\d, ]+\)/', $argv[1])) {
-        $where = ' AND groups_id IN '.$argv[1];
-    } elseif (isset($argv[1]) && $argv[1] === 'misc') {
+
+    if (isset($groups) && is_numeric($groups)) {
+        $where = ' AND groups_id = '.$groups;
+    } elseif (isset($groups) && preg_match('/\([\d, ]+\)/', $groups)) {
+        $where = ' AND groups_id IN '.$groups;
+    } elseif (isset($groups) && $groups === 'misc') {
         $where = sprintf(' AND categories_id IN (%s)', $otherCats);
     }
-    if (isset($argv[2]) && $argv[2] === 'test') {
+
+    if ($test === 'test') {
         $update = false;
     }
 
-    if (isset($argv[1]) && (is_numeric($argv[1]) || preg_match('/\([\d, ]+\)/', $argv[1]))) {
-        $colorCli->header('Categorizing all releases in '.$argv[1].' using searchname. This can take a while, be patient.');
-    } elseif (isset($argv[1]) && $argv[1] === 'misc') {
+    if (isset($groups) && (is_numeric($groups) || preg_match('/\([\d, ]+\)/', $groups))) {
+        $colorCli->header('Categorizing all releases in '.$groups.' using searchname. This can take a while, be patient.');
+    } elseif (isset($groups) && $groups === 'misc') {
         $colorCli->header('Categorizing all releases in misc categories using searchname. This can take a while, be patient.');
     } else {
         $colorCli->header('Categorizing all releases using searchname. This can take a while, be patient.');
     }
     $timeStart = now();
-    if (isset($argv[1]) && (is_numeric($argv[1]) || preg_match('/\([\d, ]+\)/', $argv[1]) || $argv[1] === 'misc')) {
-        $chgCount = categorizeRelease(str_replace(' AND', 'WHERE', $where), $update, true);
+    if (isset($groups) && (is_numeric($groups) || preg_match('/\([\d, ]+\)/', $groups) || $groups === 'misc')) {
+        $chgCount = categorizeRelease(str_replace(' AND', 'WHERE', $where).' ORDER BY id DESC', $update, true);
     } else {
-        $chgCount = categorizeRelease('', $update, true);
+        $where = $offset !== null ? 'ORDER BY id DESC LIMIT '.$offset.', '.$limit : 'ORDER BY id DESC';
+        $chgCount = categorizeRelease($where, $update, true);
     }
     $time = now()->diffInSeconds($timeStart);
     if ($update === true) {
-        $colorCli->header('Finished re-categorizing '.number_format($chgCount).' releases in '.$time.' , using the searchname.'.PHP_EOL);
+        $colorCli->header('Finished re-categorizing '.number_format($chgCount).' releases in '.$time.' seconds, using the searchname.'.PHP_EOL);
     } else {
         $colorCli->header('Finished re-categorizing in '.$time.' seconds , using the searchname.'.PHP_EOL
             .'This would have changed '.number_format($chgCount).' releases but no updates were done.'.PHP_EOL);
@@ -70,16 +76,22 @@ function reCategorize($argv)
 // Returns the quantity of categorized releases.
 function categorizeRelease($where, $update = true, $echoOutput = false)
 {
+    global $colorCli;
+    if ($echoOutput) {
+        $colorCli->tmuxOrange('Memory limit is '.ini_get('memory_limit'), true);
+    }
+
+    $memoryLimit = str_replace(['G', 'M', 'K'], ['000000000', '000000', '000'], ini_get('memory_limit'));
     $cat = new Categorize();
     $consoleTools = new ConsoleTools();
     $relCount = $chgCount = 0;
-    $consoleTools->primary('SELECT id, searchname, fromname, groups_id, categories_id FROM releases '.$where);
-    $resRel = DB::select('SELECT id, searchname, fromname, groups_id, categories_id FROM releases '.$where);
+    $consoleTools->primary($query = 'SELECT id, searchname, fromname, groups_id, categories_id FROM releases '.$where);
+    $resRel = DB::select($query);
     $total = \count($resRel);
     if ($total > 0) {
         foreach ($resRel as $rowRel) {
             $catId = $cat->determineCategory($rowRel->groups_id, $rowRel->searchname, $rowRel->fromname);
-            if ((int) $rowRel->categories_id !== $catId) {
+            if ((int) $rowRel->categories_id !== $catId['categories_id']) {
                 if ($update === true) {
                     DB::update(
                         sprintf(
@@ -105,12 +117,27 @@ function categorizeRelease($where, $update = true, $echoOutput = false)
                     if (! empty($release)) {
                         $release->retag($catId['tags']);
                     }
+                    unset($release);
                 }
                 $chgCount++;
             }
             $relCount++;
+
+            unset($rowRel);
+
             if ($echoOutput) {
-                $consoleTools->overWritePrimary('Re-Categorized: ['.number_format($chgCount).'] '.$consoleTools->percentString($relCount, $total));
+                $consoleTools->overWritePrimary(
+                    'Re-Categorized: ['.number_format($chgCount).'] '.$consoleTools->percentString($relCount, $total).
+                    ' | MEM: '.$consoleTools->percentString(memory_get_usage(true) / 1000000, $memoryLimit / 1000000)
+                );
+            }
+
+            if ($memoryLimit - memory_get_usage(true) < 40 * 1000000) {
+                if ($echoOutput) {
+                    $colorCli->alternate('Breaking due to less than 40M available free memory.', true);
+                }
+
+                exit(27);
             }
         }
     }


### PR DESCRIPTION
I ran into OOM issues when running `recategorize.php` and my first
attempt at memory cleanup didn't do much good. I then decided to then
make some adjustments that allow me to run it in batches, processing
chunks of releases at a time. The end product is
`cli/recategorize-range.sh` which takes three parameters -- an offset,
limit and batch size. It runs `categorize.php` for each batch and will
automatically restart that batch if interrupted due to low memory.

I've also noticed that as memory grows, recategorizing releases slows
down dramatically so running smaller batch sizes is best. I usually go
with a batch size of 2.5k.

Sort-of closes #1150