### PR TITLE
Fix scan type call

### DIFF
--- a/Blacklight/Binaries.php
+++ b/Blacklight/Binaries.php
@@ -559,7 +559,7 @@ class Binaries
 
         $returnArray = $stdHeaders = [];
 
-        $partRepair = ($type === 'partrepair');
+        $partRepair = ($type === 'missed_parts');
         $this->addToPartRepair = ($type === 'update' && $this->_partRepair);
 
         // Download the headers.


### PR DESCRIPTION
In bef52df2f6cd2e79c9ab1193656bd8086737916a the call to `scan`'s type variable was changed from `partrepair` to `missed_parts` but the check that uses the type inside `scan` wasn't updated with it. This led to missing parts never getting deleted and all missing parts having to be retried three times before removal.