### PR TITLE
Fix bad URL in /browse/All

### DIFF
--- a/resources/views/themes/Gentele/browse.tpl
+++ b/resources/views/themes/Gentele/browse.tpl
@@ -1,11 +1,11 @@
 <div class="header">
 	<div class="breadcrumb-wrapper">
 		<ul class="breadcrumb">
-			<li><a href="{{url("{$site->home_link}")}}">Home</a></li>
+			<li><a href="{{url("{$site->home_link}")}}">Home</a></li>&nbsp;
 			/
 			<a href="{{url("/{if preg_match('/^alt\.binaries|a\.b|dk\./i', $parentcat)}browse/group?g={else}browse/{/if}{if ($parentcat == 'music')}Audio{else}{$parentcat}{/if}")}}">{$parentcat}</a>
-			/ {if ($catname != '' && $catname != 'all')} <a
-				href="{url("/browse/{$parentcat}/{$catname}")}}">{$catname}</a>{/if}
+			{if ($catname != '' && $catname != 'all')}/  <a
+				href="{{url("/browse/{$parentcat}/{$catname}")}}">{$catname}</a>{/if}
 		</ul>
 	</div>
 </div>


### PR DESCRIPTION
I fix the case of
- going to `/browse/All`
- value of URL is `browse//All%7D`

Be careful that in this case, we see`Home  /  /  All`

The double `//` is because in case of the `All` there is no `$parentcat` 

If we really change` && $catname != 'all'` to `&& $catname != 'All'`, we would see `Home  /  /`
So I didn't fix that