### PR TITLE
Make ManticoreSearch private

### DIFF
--- a/Blacklight/Releases.php
+++ b/Blacklight/Releases.php
@@ -24,9 +24,9 @@ class Releases extends Release
 
     public const PASSWD_RAR = 1; // Definitely passworded.
 
-    public ManticoreSearch $manticoreSearch;
-
     public int $passwordStatus;
+
+    private ManticoreSearch $manticoreSearch;
 
     private ElasticSearchSiteSearch $elasticSearch;
 


### PR DESCRIPTION
Fixes serialization error with Manticore PHP >3.2.x