### PR TITLE
Adjust readme typographical error

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Use [mysqltuner.pl](http://mysqltuner.pl "MySQL tuner - Use it!") for recommenda
 
  NNTmux is GPL v3. See LICENSE.txt for the full license.
 
- All external libraries will have their full licenses in their respectful folders.
+ All external libraries will have their full licenses in their respective folders.
 
 
 


### PR DESCRIPTION
This pull request includes a minor correction to the `README.md` file. The change fixes a typographical error in the documentation.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L81-R81): Corrected "respectful" to "respective" in the sentence about external libraries' licenses.