### PR TITLE
Fix error on some tmux windows by disabling highlight for active tmux…

### DIFF
--- a/misc/update/tmux/tmux.conf
+++ b/misc/update/tmux/tmux.conf
@@ -36,7 +36,7 @@ set -g status-interval 5 # default = 15 seconds
 set -g status-right "#[fg=yellow]#(free -h | grep 'Mem' | awk '{ print \"RAM Used: \"$3\", Cached: \"$6\", \";}')#(free -m | grep 'Swap' | awk '{ print \"Swapped: \"$3;}')M #[fg=cyan,bold] #(uptime | cut -d ',' -f 4-)"
 
 # Highlight active window
-set-window-option -g window-status-current-bg red
+#set-window-option -g window-status-current-bg red
 
 # Scrollback line buffer per pane
 set -g history-limit 6000 # 6000 lines of scrollback history


### PR DESCRIPTION
… window background.

Commented out the configuration line setting a red background for active windows. This change removes the highlight to provide a more neutral and cleaner appearance.


This would resolve a probleme appearing in one of the tmux screen that make it crash.