### PR TITLE
Fix conditional check for release object in API controller

### DIFF
--- a/app/Http/Controllers/Api/ApiController.php
+++ b/app/Http/Controllers/Api/ApiController.php
@@ -298,7 +298,7 @@ class ApiController extends BasePageController
                 UserRequest::addApiRequest($apiKey, $request->getRequestUri());
                 $rel = Release::query()->where('guid', $request->input('id'))->first(['id', 'searchname']);
 
-                if ($rel->isNotEmpty()) {
+                if ($rel && $rel->isNotEmpty()) {
                     $data = ReleaseNfo::getReleaseNfo($rel->id);
                     if (! empty($data)) {
                         if ($request->has('o') && $request->input('o') === 'file') {


### PR DESCRIPTION
Previously, the condition did not account for cases where `$rel` could be null, potentially causing an error. This update ensures the check validates that `$rel` exists before calling the `isNotEmpty()` method.