### PR TITLE
Remove PHP 8.2 test since it's no longer compatible

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [ 8.2, 8.3, 8.4 ]
+        php: [ 8.3, 8.4 ]
 
     name: PHP ${{ matrix.php }}
     services:


### PR DESCRIPTION
Some of the libs used are no longer compatible with php 8.2, this is why scrutinizer is failing 