### PR TITLE
Change default connection to MariaDB

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-DB_CONNECTION=mysql
+DB_CONNECTION=mariadb
 DB_HOST=127.0.0.1
 DB_PORT=3306
 DB_ROOTPASSWORD=  #only needed for install.sh for docker based installation


### PR DESCRIPTION
This makes schema import work by default as the dump is called `mariadb-schema.sql`