### PR TITLE
refactor: replace strpos with PHP 8.x string functions

### DIFF
--- a/app/Console/Commands/NntmuxCheckIndex.php
+++ b/app/Console/Commands/NntmuxCheckIndex.php
@@ -170,9 +170,9 @@ class NntmuxCheckIndex extends Command
                 $this->error("HTTP Status: {$statusCode}");
 
                 // Check if it's a table not found error
-                if (strpos($body, 'no such table') !== false ||
-                    strpos($body, 'unknown table') !== false ||
-                    strpos($body, "doesn't exist") !== false) {
+                if (str_contains($body, 'no such table') ||
+                    str_contains($body, 'unknown table') ||
+                    str_contains($body, "doesn't exist")) {
                     $this->error("ManticoreSearch table '{$indexName}' does not exist.");
 
                     return;

--- a/app/Models/Settings.php
+++ b/app/Models/Settings.php
@@ -176,7 +176,7 @@ class Settings extends Model
         // Convert numeric strings to actual numbers
         if (is_numeric($value)) {
             // Check if it's an integer or float
-            if (strpos((string) $value, '.') !== false) {
+            if (str_contains((string) $value, '.')) {
                 return (float) $value;
             }
 

--- a/app/Services/IGDBService.php
+++ b/app/Services/IGDBService.php
@@ -647,7 +647,7 @@ class IGDBService
 
         if (! empty($imageData['url'])) {
             $url = $imageData['url'];
-            if (strpos($url, '//') === 0) {
+            if (str_starts_with($url, '//')) {
                 $url = 'https:'.$url;
             }
 

--- a/app/Services/IRCClient.php
+++ b/app/Services/IRCClient.php
@@ -437,7 +437,7 @@ class IRCClient
             $pong === false
             || (
                 (time() - $this->_lastPing) > ($this->_socket_timeout / 2)
-                && strpos((string) $this->_buffer, 'PONG') !== 0
+                && ! str_starts_with((string) $this->_buffer, 'PONG')
             )
         ) {
             $this->_reconnect();


### PR DESCRIPTION
Replace legacy `strpos()` calls with PHP 8.x `str_contains()` and `str_starts_with()` for better readability and intent.