### PR TITLE
refactor: replace Guzzle HTTP client with Laravel Http facade

### DIFF
--- a/app/Console/Commands/NntmuxCheckIndex.php
+++ b/app/Console/Commands/NntmuxCheckIndex.php
@@ -8,9 +8,8 @@ use App\Facades\Elasticsearch;
 use App\Services\Search\Support\ElasticsearchResponseHelper;
 use Elastic\Elasticsearch\Client as ElasticsearchClient;
 use Exception;
-use GuzzleHttp\Client;
-use GuzzleHttp\Exception\RequestException;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Http;
 
 class NntmuxCheckIndex extends Command
 {
@@ -146,25 +145,16 @@ class NntmuxCheckIndex extends Command
             // Use HTTP API endpoint
             $baseUrl = "http://{$host}:{$port}";
 
-            // Check if table exists using HTTP API
-            $client = new Client([
-                'base_uri' => $baseUrl,
-                'timeout' => 10,
-                'http_errors' => false, // Don't throw on HTTP errors
-            ]);
-
             // Use raw mode which seems to work
             $query = "SELECT COUNT(*) FROM {$indexName}";
 
-            $response = $client->post('/sql?mode=raw', [
-                'body' => $query,
-                'headers' => [
-                    'Content-Type' => 'text/plain',
-                ],
-            ]);
+            $response = Http::timeout(10)
+                ->baseUrl($baseUrl)
+                ->withBody($query, 'text/plain')
+                ->post('/sql?mode=raw');
 
-            $statusCode = $response->getStatusCode();
-            $body = $response->getBody()->getContents();
+            $statusCode = $response->status();
+            $body = $response->body();
 
             if ($statusCode !== 200) {
                 $this->error("HTTP Status: {$statusCode}");
@@ -198,15 +188,13 @@ class NntmuxCheckIndex extends Command
             if ($docCount > 0) {
                 $sampleQuery = "SELECT * FROM {$indexName} LIMIT 1";
 
-                $sampleResponse = $client->post('/sql?mode=raw', [
-                    'body' => $sampleQuery,
-                    'headers' => [
-                        'Content-Type' => 'text/plain',
-                    ],
-                ]);
+                $sampleResponse = Http::timeout(10)
+                    ->baseUrl($baseUrl)
+                    ->withBody($sampleQuery, 'text/plain')
+                    ->post('/sql?mode=raw');
 
-                if ($sampleResponse->getStatusCode() === 200) {
-                    $sampleBody = $sampleResponse->getBody()->getContents();
+                if ($sampleResponse->successful()) {
+                    $sampleBody = $sampleResponse->body();
                     $sampleJson = json_decode($sampleBody, true);
 
                     if ($sampleJson !== null && isset($sampleJson['data'][0])) {
@@ -230,15 +218,13 @@ class NntmuxCheckIndex extends Command
             // Get table structure
             try {
                 $describeQuery = "DESCRIBE {$indexName}";
-                $describeResponse = $client->post('/sql?mode=raw', [
-                    'body' => $describeQuery,
-                    'headers' => [
-                        'Content-Type' => 'text/plain',
-                    ],
-                ]);
+                $describeResponse = Http::timeout(10)
+                    ->baseUrl($baseUrl)
+                    ->withBody($describeQuery, 'text/plain')
+                    ->post('/sql?mode=raw');
 
-                if ($describeResponse->getStatusCode() === 200) {
-                    $describeBody = $describeResponse->getBody()->getContents();
+                if ($describeResponse->successful()) {
+                    $describeBody = $describeResponse->body();
                     $describeJson = json_decode($describeBody, true);
 
                     if ($describeJson !== null && isset($describeJson['data'])) {
@@ -259,11 +245,8 @@ class NntmuxCheckIndex extends Command
                 // Ignore describe errors
             }
 
-        } catch (Exception $e) {
+        } catch (\Throwable $e) {
             $this->error("Error checking ManticoreSearch table: {$e->getMessage()}");
-            if ($e instanceof RequestException && $e->hasResponse()) {
-                $this->error('Response body: '.$e->getResponse()->getBody());
-            }
         }
     }
 

--- a/app/Extensions/helper/helpers.php
+++ b/app/Extensions/helper/helpers.php
@@ -5,14 +5,11 @@ declare(strict_types=1);
 use App\Models\Country as CountryModel;
 use App\Models\Release;
 use App\Services\Nzb\NzbService;
-use GuzzleHttp\Client;
-use GuzzleHttp\Cookie\CookieJar;
-use GuzzleHttp\Cookie\SetCookie;
-use GuzzleHttp\Exception\RequestException;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use STS\ZipStream\Builder;
@@ -43,25 +40,23 @@ if (! function_exists('getRawHtml')) {
             }
         }
 
-        // Standard method
-        $cookieJar = new CookieJar;
-        $client = new Client(['headers' => ['User-Agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246']]);
-        if ($cookie !== false && $cookie !== null && $cookie !== '') {
-            $cookie = $cookieJar->setCookie(SetCookie::fromString((string) $cookie));
-            $client = new Client(['cookies' => $cookie, 'headers' => ['User-Agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246']]);
+        $userAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246';
+        $headers = ['User-Agent' => $userAgent];
+
+        if (is_string($cookie) && $cookie !== '') {
+            $headers['Cookie'] = $cookie;
         }
+
         try {
-            $response = $client->get($url)->getBody()->getContents();
-            $jsonResponse = json_decode($response, true);
+            $response = Http::withHeaders($headers)->get($url);
+            $body = $response->body();
+            $jsonResponse = json_decode($body, true);
             if (json_last_error() === JSON_ERROR_NONE) {
                 $response = $jsonResponse;
+            } else {
+                $response = $body;
             }
-        } catch (RequestException $e) {
-            if (function_exists('config') && config('app.debug') === true) {
-                Log::error($e->getMessage());
-            }
-            $response = false;
-        } catch (RuntimeException $e) {
+        } catch (Throwable $e) {
             if (function_exists('config') && config('app.debug') === true) {
                 Log::error($e->getMessage());
             }

--- a/app/Services/GoogleBooksService.php
+++ b/app/Services/GoogleBooksService.php
@@ -5,34 +5,21 @@ declare(strict_types=1);
 namespace App\Services;
 
 use Carbon\Carbon;
-use GuzzleHttp\Client;
-use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
 class GoogleBooksService
 {
     protected const API_URL = 'https://www.googleapis.com/books/v1/volumes';
 
-    protected Client $client;
-
     protected ?string $apiKey;
 
     protected int $maxResults = 5;
 
-    public function __construct(?Client $client = null, ?string $apiKey = null)
+    public function __construct(?string $apiKey = null)
     {
         $this->apiKey = trim($apiKey ?? (string) config('nntmux_api.google_books_api_key', '')) ?: null;
-
-        $this->client = $client ?? new Client([
-            'timeout' => 15,
-            'connect_timeout' => 10,
-            'http_errors' => false,
-            'headers' => [
-                'Accept' => 'application/json',
-                'User-Agent' => 'NNTmux/1.0',
-            ],
-        ]);
     }
 
     public function hasApiKey(): bool
@@ -118,17 +105,24 @@ class GoogleBooksService
                 $query['key'] = $this->apiKey;
             }
 
-            $response = $this->client->get(self::API_URL, ['query' => $query]);
-            if ($response->getStatusCode() !== 200) {
-                Log::warning('Google Books API request failed', ['status' => $response->getStatusCode()]);
+            $response = Http::timeout(15)
+                ->connectTimeout(10)
+                ->withHeaders([
+                    'Accept' => 'application/json',
+                    'User-Agent' => 'NNTmux/1.0',
+                ])
+                ->get(self::API_URL, $query);
+
+            if (! $response->successful()) {
+                Log::warning('Google Books API request failed', ['status' => $response->status()]);
 
                 return null;
             }
 
-            $decoded = json_decode($response->getBody()->getContents(), true);
+            $decoded = $response->json();
 
             return is_array($decoded) ? $decoded : null;
-        } catch (GuzzleException $e) {
+        } catch (\Throwable $e) {
             Log::error('Google Books API request error: '.$e->getMessage());
 
             return null;

--- a/app/Services/ImdbScraper.php
+++ b/app/Services/ImdbScraper.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace App\Services;
 
-use GuzzleHttp\Client;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use voku\helper\HtmlDomParser;
@@ -20,8 +20,6 @@ class ImdbScraper
 
     protected const string IMDBAPI_DEV_COOLDOWN_CACHE_KEY = 'imdbapi_dev:cooldown';
 
-    protected Client $client;
-
     protected string $imdbApiDevBaseUrl;
 
     protected bool $lastRequestWasBlocked = false;
@@ -32,21 +30,9 @@ class ImdbScraper
 
     protected ?string $lastFallbackFailureReason = null;
 
-    public function __construct(?Client $client = null)
+    public function __construct()
     {
         $this->imdbApiDevBaseUrl = rtrim((string) config('nntmux_api.imdbapi_dev_base_url', 'https://api.imdbapi.dev'), '/');
-        $this->client = $client ?? new Client([
-            'timeout' => 10,
-            'connect_timeout' => 10,
-            'http_errors' => false,
-            'allow_redirects' => true,
-            'headers' => [
-                'User-Agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36',
-                'Accept-Language' => 'en-US,en;q=0.9',
-                'Cache-Control' => 'no-cache',
-                'Pragma' => 'no-cache',
-            ],
-        ]);
     }
 
     public function wasBlockedByWaf(): bool
@@ -97,16 +83,21 @@ class ImdbScraper
         $url = 'https://www.imdb.com/title/tt'.$id.'/';
 
         try {
-            $response = $this->client->get($url, [
-                'headers' => [
+            $response = Http::timeout(10)
+                ->connectTimeout(10)
+                ->withHeaders([
+                    'User-Agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36',
+                    'Accept-Language' => 'en-US,en;q=0.9',
+                    'Cache-Control' => 'no-cache',
+                    'Pragma' => 'no-cache',
                     'Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',
                     'Referer' => 'https://www.imdb.com/',
                     'Upgrade-Insecure-Requests' => '1',
-                ],
-            ]);
+                ])
+                ->get($url);
 
-            $statusCode = $response->getStatusCode();
-            $html = (string) $response->getBody();
+            $statusCode = $response->status();
+            $html = $response->body();
 
             if ($this->isWafResponse($statusCode, $html)) {
                 $this->lastRequestWasBlocked = true;
@@ -199,17 +190,22 @@ class ImdbScraper
         $url = 'https://v2.sg.media-imdb.com/suggestion/'.urlencode($prefix).'/'.urlencode($slug).'.json';
 
         try {
-            $res = $this->client->get($url, [
-                'headers' => [
+            $res = Http::timeout(10)
+                ->connectTimeout(10)
+                ->withHeaders([
+                    'User-Agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36',
+                    'Accept-Language' => 'en-US,en;q=0.9',
+                    'Cache-Control' => 'no-cache',
+                    'Pragma' => 'no-cache',
                     'Accept' => 'application/json,text/plain,*/*',
                     'Origin' => 'https://www.imdb.com',
                     'Referer' => 'https://www.imdb.com/find/?q='.rawurlencode($query).'&s=tt',
-                ],
-            ]);
-            $body = (string) $res->getBody();
+                ])
+                ->get($url);
+            $body = $res->body();
 
             $results = [];
-            if ($res->getStatusCode() === 200 && ! $this->isWafResponse($res->getStatusCode(), $body)) {
+            if ($res->successful() && ! $this->isWafResponse($res->status(), $body)) {
                 $results = $this->parseSuggestionJson($body);
             }
 
@@ -321,29 +317,36 @@ class ImdbScraper
         try {
             $this->markImdbApiDevAttempt();
 
-            $response = $this->client->get($this->imdbApiDevBaseUrl.'/titles/tt'.$id, [
-                'headers' => [
+            $response = Http::timeout(10)
+                ->connectTimeout(10)
+                ->withHeaders([
+                    'User-Agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36',
+                    'Accept-Language' => 'en-US,en;q=0.9',
+                    'Cache-Control' => 'no-cache',
+                    'Pragma' => 'no-cache',
                     'Accept' => 'application/json',
-                ],
-            ]);
+                ])
+                ->get($this->imdbApiDevBaseUrl.'/titles/tt'.$id);
 
-            if ($response->getStatusCode() === 429) {
+            $statusCode = $response->status();
+
+            if ($statusCode === 429) {
                 $this->lastFallbackFailureReason = 'fallback_rate_limited';
                 $this->activateImdbApiDevCooldown();
 
                 return false;
             }
 
-            if ($response->getStatusCode() !== 200) {
+            if (! $response->successful()) {
                 $this->lastFallbackFailureReason = 'fallback_http_failure';
-                if ($response->getStatusCode() >= 500) {
+                if ($statusCode >= 500) {
                     $this->activateImdbApiDevCooldown();
                 }
 
                 return false;
             }
 
-            $payload = json_decode((string) $response->getBody(), true);
+            $payload = $response->json();
             if (! is_array($payload)) {
                 $this->lastFallbackFailureReason = 'fallback_invalid_json';
 
@@ -895,15 +898,20 @@ class ImdbScraper
         $url = 'https://www.imdb.com/find/?q='.rawurlencode($query).'&s=tt';
 
         try {
-            $response = $this->client->get($url, [
-                'headers' => [
+            $response = Http::timeout(10)
+                ->connectTimeout(10)
+                ->withHeaders([
+                    'User-Agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36',
+                    'Accept-Language' => 'en-US,en;q=0.9',
+                    'Cache-Control' => 'no-cache',
+                    'Pragma' => 'no-cache',
                     'Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',
                     'Referer' => 'https://www.imdb.com/',
-                ],
-            ]);
+                ])
+                ->get($url);
 
-            $statusCode = $response->getStatusCode();
-            $html = (string) $response->getBody();
+            $statusCode = $response->status();
+            $html = $response->body();
 
             if ($this->isWafResponse($statusCode, $html)) {
                 $this->lastRequestWasBlocked = true;

--- a/app/Services/ImdbScraper.php
+++ b/app/Services/ImdbScraper.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services;
 
+use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
@@ -56,6 +57,23 @@ class ImdbScraper
     }
 
     /**
+     * Build HTTP request with standard IMDb browser headers.
+     *
+     * @param  array<string, string>  $extra  Additional headers to merge
+     */
+    private function imdbRequest(array $extra = []): PendingRequest
+    {
+        return Http::timeout(10)
+            ->connectTimeout(10)
+            ->withHeaders(array_merge([
+                'User-Agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36',
+                'Accept-Language' => 'en-US,en;q=0.9',
+                'Cache-Control' => 'no-cache',
+                'Pragma' => 'no-cache',
+            ], $extra));
+    }
+
+    /**
      * Fetch a movie by IMDB numeric ID.
      *
      * @param  string  $id  Numeric part without 'tt'.
@@ -83,18 +101,11 @@ class ImdbScraper
         $url = 'https://www.imdb.com/title/tt'.$id.'/';
 
         try {
-            $response = Http::timeout(10)
-                ->connectTimeout(10)
-                ->withHeaders([
-                    'User-Agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36',
-                    'Accept-Language' => 'en-US,en;q=0.9',
-                    'Cache-Control' => 'no-cache',
-                    'Pragma' => 'no-cache',
-                    'Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',
-                    'Referer' => 'https://www.imdb.com/',
-                    'Upgrade-Insecure-Requests' => '1',
-                ])
-                ->get($url);
+            $response = $this->imdbRequest([
+                'Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',
+                'Referer' => 'https://www.imdb.com/',
+                'Upgrade-Insecure-Requests' => '1',
+            ])->get($url);
 
             $statusCode = $response->status();
             $html = $response->body();
@@ -190,18 +201,11 @@ class ImdbScraper
         $url = 'https://v2.sg.media-imdb.com/suggestion/'.urlencode($prefix).'/'.urlencode($slug).'.json';
 
         try {
-            $res = Http::timeout(10)
-                ->connectTimeout(10)
-                ->withHeaders([
-                    'User-Agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36',
-                    'Accept-Language' => 'en-US,en;q=0.9',
-                    'Cache-Control' => 'no-cache',
-                    'Pragma' => 'no-cache',
-                    'Accept' => 'application/json,text/plain,*/*',
-                    'Origin' => 'https://www.imdb.com',
-                    'Referer' => 'https://www.imdb.com/find/?q='.rawurlencode($query).'&s=tt',
-                ])
-                ->get($url);
+            $res = $this->imdbRequest([
+                'Accept' => 'application/json,text/plain,*/*',
+                'Origin' => 'https://www.imdb.com',
+                'Referer' => 'https://www.imdb.com/find/?q='.rawurlencode($query).'&s=tt',
+            ])->get($url);
             $body = $res->body();
 
             $results = [];
@@ -317,16 +321,9 @@ class ImdbScraper
         try {
             $this->markImdbApiDevAttempt();
 
-            $response = Http::timeout(10)
-                ->connectTimeout(10)
-                ->withHeaders([
-                    'User-Agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36',
-                    'Accept-Language' => 'en-US,en;q=0.9',
-                    'Cache-Control' => 'no-cache',
-                    'Pragma' => 'no-cache',
-                    'Accept' => 'application/json',
-                ])
-                ->get($this->imdbApiDevBaseUrl.'/titles/tt'.$id);
+            $response = $this->imdbRequest([
+                'Accept' => 'application/json',
+            ])->get($this->imdbApiDevBaseUrl.'/titles/tt'.$id);
 
             $statusCode = $response->status();
 
@@ -898,17 +895,10 @@ class ImdbScraper
         $url = 'https://www.imdb.com/find/?q='.rawurlencode($query).'&s=tt';
 
         try {
-            $response = Http::timeout(10)
-                ->connectTimeout(10)
-                ->withHeaders([
-                    'User-Agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36',
-                    'Accept-Language' => 'en-US,en;q=0.9',
-                    'Cache-Control' => 'no-cache',
-                    'Pragma' => 'no-cache',
-                    'Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',
-                    'Referer' => 'https://www.imdb.com/',
-                ])
-                ->get($url);
+            $response = $this->imdbRequest([
+                'Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',
+                'Referer' => 'https://www.imdb.com/',
+            ])->get($url);
 
             $statusCode = $response->status();
             $html = $response->body();

--- a/app/Services/IsbnDbService.php
+++ b/app/Services/IsbnDbService.php
@@ -5,36 +5,22 @@ declare(strict_types=1);
 namespace App\Services;
 
 use Carbon\Carbon;
-use GuzzleHttp\Client;
-use GuzzleHttp\Exception\GuzzleException;
+use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
-use Psr\Http\Message\ResponseInterface;
 
 class IsbnDbService
 {
     protected const API_URL = 'https://api2.isbndb.com';
 
-    protected Client $client;
-
     protected string $apiKey;
 
     protected int $pageSize = 5;
 
-    public function __construct(?Client $client = null, ?string $apiKey = null)
+    public function __construct(?string $apiKey = null)
     {
         $this->apiKey = trim($apiKey ?? (string) config('nntmux_api.isbndb_api_key', ''));
-
-        $this->client = $client ?? new Client([
-            'base_uri' => self::API_URL,
-            'timeout' => 15,
-            'connect_timeout' => 10,
-            'http_errors' => false,
-            'headers' => [
-                'Accept' => 'application/json',
-                'User-Agent' => 'NNTmux/1.0',
-            ],
-        ]);
     }
 
     public function isConfigured(): bool
@@ -129,14 +115,16 @@ class IsbnDbService
         }
 
         try {
-            $response = $this->client->get($path, [
-                'headers' => [
+            $response = Http::timeout(15)
+                ->connectTimeout(10)
+                ->withHeaders([
+                    'Accept' => 'application/json',
+                    'User-Agent' => 'NNTmux/1.0',
                     'Authorization' => $this->apiKey,
-                ],
-                'query' => $query,
-            ]);
+                ])
+                ->get(self::API_URL.$path, $query);
 
-            $statusCode = $response->getStatusCode();
+            $statusCode = $response->status();
             $this->logRateLimitHeaders($response);
 
             if ($statusCode === 404) {
@@ -149,16 +137,16 @@ class IsbnDbService
                 return null;
             }
 
-            if ($statusCode !== 200) {
+            if (! $response->successful()) {
                 Log::warning("ISBNdb request returned status {$statusCode}");
 
                 return null;
             }
 
-            $data = json_decode($response->getBody()->getContents(), true);
+            $data = $response->json();
 
             return is_array($data) ? $data : null;
-        } catch (GuzzleException $e) {
+        } catch (\Throwable $e) {
             Log::error('ISBNdb API request error: '.$e->getMessage());
 
             return null;
@@ -225,10 +213,10 @@ class IsbnDbService
         return strtoupper((string) preg_replace('/[^0-9X]/i', '', $isbn));
     }
 
-    private function logRateLimitHeaders(ResponseInterface $response): void
+    private function logRateLimitHeaders(Response $response): void
     {
-        $rateLimit = $response->getHeaderLine('ratelimit');
-        $rateLimitPolicy = $response->getHeaderLine('ratelimit-policy');
+        $rateLimit = $response->header('ratelimit') ?? '';
+        $rateLimitPolicy = $response->header('ratelimit-policy') ?? '';
 
         if ($rateLimit === '' && $rateLimitPolicy === '') {
             return;

--- a/app/Services/ItunesService.php
+++ b/app/Services/ItunesService.php
@@ -5,9 +5,8 @@ declare(strict_types=1);
 namespace App\Services;
 
 use Carbon\Carbon;
-use GuzzleHttp\Client;
-use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
 /**
@@ -23,24 +22,9 @@ class ItunesService
 
     protected const LOOKUP_URL = 'https://itunes.apple.com/lookup';
 
-    protected Client $client;
-
     protected int $limit = 25;
 
     protected string $country = 'US';
-
-    public function __construct()
-    {
-        $this->client = new Client([
-            'timeout' => 15,
-            'connect_timeout' => 10,
-            'http_errors' => false,
-            'headers' => [
-                'Accept' => 'application/json',
-                'User-Agent' => 'NNTmux/1.0',
-            ],
-        ]);
-    }
 
     /**
      * Set the result limit.
@@ -127,21 +111,24 @@ class ItunesService
         }
 
         try {
-            $response = $this->client->get(self::LOOKUP_URL, [
-                'query' => [
+            $response = Http::timeout(15)
+                ->connectTimeout(10)
+                ->withHeaders([
+                    'Accept' => 'application/json',
+                    'User-Agent' => 'NNTmux/1.0',
+                ])
+                ->get(self::LOOKUP_URL, [
                     'id' => $id,
                     'country' => $this->country,
-                ],
-            ]);
+                ]);
 
-            $statusCode = $response->getStatusCode();
-            if ($statusCode !== 200) {
-                Log::warning("iTunes API lookup returned status {$statusCode}");
+            if (! $response->successful()) {
+                Log::warning("iTunes API lookup returned status {$response->status()}");
 
                 return null;
             }
 
-            $data = json_decode($response->getBody()->getContents(), true);
+            $data = $response->json();
 
             if (! isset($data['results']) || empty($data['results'])) {
                 return null;
@@ -150,7 +137,7 @@ class ItunesService
             Cache::put($cacheKey, $data['results'][0], now()->addDays(7));
 
             return $data['results'][0];
-        } catch (GuzzleException $e) {
+        } catch (\Throwable $e) {
             Log::error('iTunes API lookup error: '.$e->getMessage());
 
             return null;
@@ -253,24 +240,27 @@ class ItunesService
         }
 
         try {
-            $response = $this->client->get(self::API_URL, [
-                'query' => [
+            $response = Http::timeout(15)
+                ->connectTimeout(10)
+                ->withHeaders([
+                    'Accept' => 'application/json',
+                    'User-Agent' => 'NNTmux/1.0',
+                ])
+                ->get(self::API_URL, [
                     'term' => $term,
                     'entity' => $entity,
                     'media' => $media,
                     'country' => $this->country,
                     'limit' => $this->limit,
-                ],
-            ]);
+                ]);
 
-            $statusCode = $response->getStatusCode();
-            if ($statusCode !== 200) {
-                Log::warning("iTunes API search returned status {$statusCode}");
+            if (! $response->successful()) {
+                Log::warning("iTunes API search returned status {$response->status()}");
 
                 return null;
             }
 
-            $data = json_decode($response->getBody()->getContents(), true);
+            $data = $response->json();
 
             if (! isset($data['results'])) {
                 return null;
@@ -280,7 +270,7 @@ class ItunesService
             Cache::put($cacheKey, $results, now()->addHours(6));
 
             return $results;
-        } catch (GuzzleException $e) {
+        } catch (\Throwable $e) {
             Log::error('iTunes API search error: '.$e->getMessage());
 
             return null;

--- a/app/Services/OpenLibraryService.php
+++ b/app/Services/OpenLibraryService.php
@@ -5,9 +5,8 @@ declare(strict_types=1);
 namespace App\Services;
 
 use Carbon\Carbon;
-use GuzzleHttp\Client;
-use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
 class OpenLibraryService
@@ -16,22 +15,7 @@ class OpenLibraryService
 
     protected const ISBN_URL = 'https://openlibrary.org/isbn/';
 
-    protected Client $client;
-
     protected int $limit = 5;
-
-    public function __construct(?Client $client = null)
-    {
-        $this->client = $client ?? new Client([
-            'timeout' => 15,
-            'connect_timeout' => 10,
-            'http_errors' => false,
-            'headers' => [
-                'Accept' => 'application/json',
-                'User-Agent' => 'NNTmux/1.0',
-            ],
-        ]);
-    }
 
     /**
      * @return array<string, mixed>|null
@@ -50,12 +34,19 @@ class OpenLibraryService
         }
 
         try {
-            $response = $this->client->get(self::ISBN_URL.rawurlencode($isbn).'.json');
-            if ($response->getStatusCode() !== 200) {
+            $response = Http::timeout(15)
+                ->connectTimeout(10)
+                ->withHeaders([
+                    'Accept' => 'application/json',
+                    'User-Agent' => 'NNTmux/1.0',
+                ])
+                ->get(self::ISBN_URL.rawurlencode($isbn).'.json');
+
+            if (! $response->successful()) {
                 return null;
             }
 
-            $data = json_decode($response->getBody()->getContents(), true);
+            $data = $response->json();
             if (! is_array($data)) {
                 return null;
             }
@@ -64,7 +55,7 @@ class OpenLibraryService
             Cache::put($cacheKey, $book, now()->addHours(24));
 
             return $book;
-        } catch (GuzzleException $e) {
+        } catch (\Throwable $e) {
             Log::error('OpenLibrary ISBN lookup error: '.$e->getMessage());
 
             return null;
@@ -98,17 +89,22 @@ class OpenLibraryService
         }
 
         try {
-            $response = $this->client->get(self::SEARCH_URL, [
-                'query' => [
+            $response = Http::timeout(15)
+                ->connectTimeout(10)
+                ->withHeaders([
+                    'Accept' => 'application/json',
+                    'User-Agent' => 'NNTmux/1.0',
+                ])
+                ->get(self::SEARCH_URL, [
                     'q' => $query,
                     'limit' => $this->limit,
-                ],
-            ]);
-            if ($response->getStatusCode() !== 200) {
+                ]);
+
+            if (! $response->successful()) {
                 return [];
             }
 
-            $data = json_decode($response->getBody()->getContents(), true);
+            $data = $response->json();
             if (! is_array($data['docs'] ?? null)) {
                 return [];
             }
@@ -123,7 +119,7 @@ class OpenLibraryService
             Cache::put($cacheKey, $results, now()->addHours(12));
 
             return $results;
-        } catch (GuzzleException $e) {
+        } catch (\Throwable $e) {
             Log::error('OpenLibrary search error: '.$e->getMessage());
 
             return [];

--- a/app/Services/PopulateAniListService.php
+++ b/app/Services/PopulateAniListService.php
@@ -6,9 +6,7 @@ namespace App\Services;
 
 use App\Models\AnidbInfo;
 use App\Models\AnidbTitle;
-use GuzzleHttp\Client;
-use GuzzleHttp\Exception\ClientException;
-use GuzzleHttp\Exception\GuzzleException;
+use Illuminate\Support\Facades\Http;
 
 class PopulateAniListService
 {
@@ -31,11 +29,6 @@ class PopulateAniListService
      * The directory to store anime covers.
      */
     public string $imgSavePath;
-
-    /**
-     * HTTP client for API requests
-     */
-    protected Client $client;
 
     /**
      * Rate limiting: track requests and timestamps
@@ -61,14 +54,6 @@ class PopulateAniListService
 
         // Use storage_path directly to match CoverController expectations
         $this->imgSavePath = storage_path('covers/anime/');
-        $this->client = new Client([
-            'base_uri' => self::API_URL,
-            'timeout' => 30,
-            'headers' => [
-                'Content-Type' => 'application/json',
-                'Accept' => 'application/json',
-            ],
-        ]);
     }
 
     /**
@@ -322,15 +307,18 @@ class PopulateAniListService
         $this->enforceRateLimit();
 
         try {
-            $response = $this->client->post('', [
-                'json' => [
+            $response = Http::timeout(30)
+                ->withHeaders([
+                    'Content-Type' => 'application/json',
+                    'Accept' => 'application/json',
+                ])
+                ->post(self::API_URL, [
                     'query' => $query,
                     'variables' => $variables,
-                ],
-            ]);
+                ]);
 
-            $statusCode = $response->getStatusCode();
-            $body = json_decode($response->getBody()->getContents(), true);
+            $statusCode = $response->status();
+            $body = $response->json();
 
             // Handle 429 Too Many Requests - pause for 15 minutes
             if ($statusCode === 429) {
@@ -348,8 +336,8 @@ class PopulateAniListService
             }
 
             // Track rate limit from headers
-            $remaining = (int) ($response->getHeader('X-RateLimit-Remaining')[0] ?? self::RATE_LIMIT_PER_MINUTE);
-            $resetAt = (int) ($response->getHeader('X-RateLimit-Reset')[0] ?? time() + 60);
+            $remaining = (int) ($response->header('X-RateLimit-Remaining') ?: self::RATE_LIMIT_PER_MINUTE);
+            $resetAt = (int) ($response->header('X-RateLimit-Reset') ?: time() + 60);
 
             // Record this request
             $this->rateLimitQueue[] = [
@@ -376,11 +364,10 @@ class PopulateAniListService
             }
 
             return false;
-        } catch (ClientException $e) {
-            // Check if this is a 429 error from Guzzle
-            $statusCode = $e->getResponse()->getStatusCode();
-            if ($statusCode === 429) {
-                $pauseUntil = time() + (15 * 60); // 15 minutes from now
+        } catch (\Throwable $e) {
+            // Check if this is a 429 error
+            if (str_contains($e->getMessage(), '429') || str_contains($e->getMessage(), 'Too Many Requests')) {
+                $pauseUntil = time() + (15 * 60);
                 self::$rateLimitPause = [
                     'timestamp' => time(),
                     'paused_until' => $pauseUntil,
@@ -393,12 +380,6 @@ class PopulateAniListService
                 throw new \Exception('AniList API rate limit exceeded (429). Paused until '.date('Y-m-d H:i:s', $pauseUntil));
             }
 
-            if ($this->echooutput) {
-                cli()->error('AniList API Request Failed: '.$e->getMessage());
-            }
-
-            return false;
-        } catch (GuzzleException $e) {
             if ($this->echooutput) {
                 cli()->error('AniList API Request Failed: '.$e->getMessage());
             }
@@ -649,8 +630,8 @@ class PopulateAniListService
                 }
             }
 
-            $response = $this->client->get($imageUrl);
-            $imageData = $response->getBody()->getContents();
+            $response = Http::timeout(30)->get($imageUrl);
+            $imageData = $response->body();
 
             // Write the image file
             $bytesWritten = file_put_contents($coverPath, $imageData);
@@ -665,13 +646,9 @@ class PopulateAniListService
             if ($this->echooutput) {
                 cli()->info("Downloaded cover image for ID {$anidbid} from AniList to {$coverPath}");
             }
-        } catch (GuzzleException $e) {
+        } catch (\Throwable $e) {
             if ($this->echooutput) {
                 cli()->warning("Failed to download cover image for ID {$anidbid}: ".$e->getMessage());
-            }
-        } catch (\Exception $e) {
-            if ($this->echooutput) {
-                cli()->error("Error saving cover image for ID {$anidbid}: ".$e->getMessage());
             }
         }
     }

--- a/app/Services/PopulateAniListService.php
+++ b/app/Services/PopulateAniListService.php
@@ -365,21 +365,6 @@ class PopulateAniListService
 
             return false;
         } catch (\Throwable $e) {
-            // Check if this is a 429 error
-            if (str_contains($e->getMessage(), '429') || str_contains($e->getMessage(), 'Too Many Requests')) {
-                $pauseUntil = time() + (15 * 60);
-                self::$rateLimitPause = [
-                    'timestamp' => time(),
-                    'paused_until' => $pauseUntil,
-                ];
-
-                if ($this->echooutput) {
-                    cli()->error('AniList API returned 429 (Too Many Requests). Pausing all API calls for 15 minutes.');
-                }
-
-                throw new \Exception('AniList API rate limit exceeded (429). Paused until '.date('Y-m-d H:i:s', $pauseUntil));
-            }
-
             if ($this->echooutput) {
                 cli()->error('AniList API Request Failed: '.$e->getMessage());
             }

--- a/tests/Unit/ImdbScraperTest.php
+++ b/tests/Unit/ImdbScraperTest.php
@@ -5,18 +5,16 @@ declare(strict_types=1);
 namespace Tests\Unit;
 
 use App\Services\ImdbScraper;
-use GuzzleHttp\Client;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Psr7\Response;
+use Illuminate\Support\Facades\Http;
 
 class ImdbScraperTest extends ImdbScraperTestCase
 {
     public function test_fetch_by_id_parses_title_page_from_fixture(): void
     {
-        $scraper = $this->makeScraperWithResponses([
-            new Response(200, ['Content-Type' => 'text/html; charset=UTF-8'], file_get_contents(base_path('tests/Fixtures/imdb/title_jsonld.html')) ?: ''),
-        ]);
+        Http::fakeSequence()
+            ->push(file_get_contents(base_path('tests/Fixtures/imdb/title_jsonld.html')) ?: '', 200);
+
+        $scraper = new ImdbScraper;
 
         $data = $scraper->fetchById('1234567');
 
@@ -36,10 +34,11 @@ class ImdbScraperTest extends ImdbScraperTestCase
 
     public function test_fetch_by_id_detects_waf_challenge_and_marks_temporary_block(): void
     {
-        $scraper = $this->makeScraperWithResponses([
-            new Response(202, ['Content-Type' => 'text/html; charset=UTF-8'], '<html><script>window.awsWafCookieDomainList=[];window.gokuProps={};</script></html>'),
-            new Response(404, ['Content-Type' => 'application/json; charset=UTF-8'], '{"code":5,"message":"NOT_FOUND"}'),
-        ]);
+        Http::fakeSequence()
+            ->push('<html><script>window.awsWafCookieDomainList=[];window.gokuProps={};</script></html>', 202)
+            ->push('{"code":5,"message":"NOT_FOUND"}', 404);
+
+        $scraper = new ImdbScraper;
 
         $data = $scraper->fetchById('1234567');
 
@@ -52,35 +51,38 @@ class ImdbScraperTest extends ImdbScraperTestCase
 
     public function test_fetch_by_id_falls_back_to_imdbapi_dev_when_title_page_is_blocked(): void
     {
-        $scraper = $this->makeScraperWithResponses([
-            new Response(202, ['Content-Type' => 'text/html; charset=UTF-8'], '<html><script>window.awsWafCookieDomainList=[];window.gokuProps={};</script></html>'),
-            new Response(200, ['Content-Type' => 'application/json; charset=UTF-8'], json_encode([
-                'id' => 'tt1234567',
-                'type' => 'movie',
-                'primaryTitle' => 'API Dev Movie',
-                'startYear' => 2026,
-                'genres' => ['Horror', 'Thriller'],
-                'plot' => 'Fallback plot from imdbapi.dev.',
-                'rating' => [
-                    'aggregateRating' => 7.4,
-                    'voteCount' => 123,
-                ],
-                'primaryImage' => [
-                    'url' => 'https://example.com/api-dev-poster.jpg',
-                ],
-                'directors' => [
-                    ['displayName' => 'API Director'],
-                ],
-                'stars' => [
-                    ['displayName' => 'API Star One'],
-                    ['displayName' => 'API Star Two'],
-                ],
-                'spokenLanguages' => [
-                    ['name' => 'English'],
-                    ['name' => 'Spanish'],
-                ],
-            ], JSON_THROW_ON_ERROR)),
-        ]);
+        $apiDevResponse = json_encode([
+            'id' => 'tt1234567',
+            'type' => 'movie',
+            'primaryTitle' => 'API Dev Movie',
+            'startYear' => 2026,
+            'genres' => ['Horror', 'Thriller'],
+            'plot' => 'Fallback plot from imdbapi.dev.',
+            'rating' => [
+                'aggregateRating' => 7.4,
+                'voteCount' => 123,
+            ],
+            'primaryImage' => [
+                'url' => 'https://example.com/api-dev-poster.jpg',
+            ],
+            'directors' => [
+                ['displayName' => 'API Director'],
+            ],
+            'stars' => [
+                ['displayName' => 'API Star One'],
+                ['displayName' => 'API Star Two'],
+            ],
+            'spokenLanguages' => [
+                ['name' => 'English'],
+                ['name' => 'Spanish'],
+            ],
+        ], JSON_THROW_ON_ERROR);
+
+        Http::fakeSequence()
+            ->push('<html><script>window.awsWafCookieDomainList=[];window.gokuProps={};</script></html>', 202)
+            ->push($apiDevResponse, 200);
+
+        $scraper = new ImdbScraper;
 
         $data = $scraper->fetchById('1234567');
 
@@ -104,13 +106,11 @@ class ImdbScraperTest extends ImdbScraperTestCase
 
     public function test_fetch_by_id_returns_false_when_imdbapi_dev_payload_lacks_title(): void
     {
-        $scraper = $this->makeScraperWithResponses([
-            new Response(202, ['Content-Type' => 'text/html; charset=UTF-8'], '<html><script>window.awsWafCookieDomainList=[];window.gokuProps={};</script></html>'),
-            new Response(200, ['Content-Type' => 'application/json; charset=UTF-8'], json_encode([
-                'id' => 'tt1234567',
-                'startYear' => 2026,
-            ], JSON_THROW_ON_ERROR)),
-        ]);
+        Http::fakeSequence()
+            ->push('<html><script>window.awsWafCookieDomainList=[];window.gokuProps={};</script></html>', 202)
+            ->push(json_encode(['id' => 'tt1234567', 'startYear' => 2026], JSON_THROW_ON_ERROR), 200);
+
+        $scraper = new ImdbScraper;
 
         $this->assertFalse($scraper->fetchById('1234567'));
         $this->assertSame('waf_block', $scraper->getLastFailureReason());
@@ -125,16 +125,17 @@ class ImdbScraperTest extends ImdbScraperTestCase
             'nntmux_api.imdbapi_dev_cooldown_seconds' => 300,
         ]);
 
-        $scraper = $this->makeScraperWithResponses([
-            new Response(202, ['Content-Type' => 'text/html; charset=UTF-8'], '<html><script>window.awsWafCookieDomainList=[];window.gokuProps={};</script></html>'),
-            new Response(200, ['Content-Type' => 'application/json; charset=UTF-8'], json_encode([
+        Http::fakeSequence()
+            ->push('<html><script>window.awsWafCookieDomainList=[];window.gokuProps={};</script></html>', 202)
+            ->push(json_encode([
                 'id' => 'tt1234567',
                 'type' => 'movie',
                 'primaryTitle' => 'First Fallback Movie',
                 'startYear' => 2026,
-            ], JSON_THROW_ON_ERROR)),
-            new Response(202, ['Content-Type' => 'text/html; charset=UTF-8'], '<html><script>window.awsWafCookieDomainList=[];window.gokuProps={};</script></html>'),
-        ]);
+            ], JSON_THROW_ON_ERROR), 200)
+            ->push('<html><script>window.awsWafCookieDomainList=[];window.gokuProps={};</script></html>', 202);
+
+        $scraper = new ImdbScraper;
 
         $first = $scraper->fetchById('1234567');
         $second = $scraper->fetchById('2345678');
@@ -153,11 +154,12 @@ class ImdbScraperTest extends ImdbScraperTestCase
             'nntmux_api.imdbapi_dev_cooldown_seconds' => 300,
         ]);
 
-        $scraper = $this->makeScraperWithResponses([
-            new Response(202, ['Content-Type' => 'text/html; charset=UTF-8'], '<html><script>window.awsWafCookieDomainList=[];window.gokuProps={};</script></html>'),
-            new Response(429, ['Content-Type' => 'application/json; charset=UTF-8'], '{"code":8,"message":"RATE_LIMITED"}'),
-            new Response(202, ['Content-Type' => 'text/html; charset=UTF-8'], '<html><script>window.awsWafCookieDomainList=[];window.gokuProps={};</script></html>'),
-        ]);
+        Http::fakeSequence()
+            ->push('<html><script>window.awsWafCookieDomainList=[];window.gokuProps={};</script></html>', 202)
+            ->push('{"code":8,"message":"RATE_LIMITED"}', 429)
+            ->push('<html><script>window.awsWafCookieDomainList=[];window.gokuProps={};</script></html>', 202);
+
+        $scraper = new ImdbScraper;
 
         $first = $scraper->fetchById('1234567');
         $this->assertFalse($first);
@@ -173,9 +175,10 @@ class ImdbScraperTest extends ImdbScraperTestCase
 
     public function test_search_parses_suggestion_json_results(): void
     {
-        $scraper = $this->makeScraperWithResponses([
-            new Response(200, ['Content-Type' => 'application/json; charset=UTF-8'], file_get_contents(base_path('tests/Fixtures/imdb/search_inception.json')) ?: '{}'),
-        ]);
+        Http::fakeSequence()
+            ->push(file_get_contents(base_path('tests/Fixtures/imdb/search_inception.json')) ?: '{}', 200);
+
+        $scraper = new ImdbScraper;
 
         $results = $scraper->search('Inception');
 
@@ -189,19 +192,5 @@ class ImdbScraperTest extends ImdbScraperTestCase
     {
         $scraper = new ImdbScraper;
         $this->assertSame([], $scraper->search(''));
-    }
-
-    /**
-     * @param  array<int, Response>  $responses
-     */
-    private function makeScraperWithResponses(array $responses): ImdbScraper
-    {
-        $mock = new MockHandler($responses);
-        $client = new Client([
-            'handler' => HandlerStack::create($mock),
-            'http_errors' => false,
-        ]);
-
-        return new ImdbScraper($client);
     }
 }

--- a/tests/Unit/Services/GoogleBooksServiceTest.php
+++ b/tests/Unit/Services/GoogleBooksServiceTest.php
@@ -5,27 +5,24 @@ declare(strict_types=1);
 namespace Tests\Unit\Services;
 
 use App\Services\GoogleBooksService;
-use GuzzleHttp\Client;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Psr7\Response;
+use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
 
 class GoogleBooksServiceTest extends TestCase
 {
     public function test_search_books_maps_google_books_payload(): void
     {
-        $mock = new MockHandler([
-            new Response(200, [], json_encode([
+        Http::fake([
+            'www.googleapis.com/books/*' => Http::response([
                 'items' => [[
                     'id' => 'gbook1',
                     'volumeInfo' => [
                         'title' => 'The Pragmatic Programmer',
                         'authors' => ['Andrew Hunt', 'David Thomas'],
                         'publisher' => 'Addison-Wesley',
-                        'publishedDate' => '1999-10-20',
+                        'publishedDate' => '1999-08-20',
                         'pageCount' => 352,
-                        'description' => '<p>Classic software engineering guidance.</p>',
+                        'description' => 'A great book.',
                         'categories' => ['Computers'],
                         'industryIdentifiers' => [
                             ['type' => 'ISBN_13', 'identifier' => '9780201616224'],
@@ -36,13 +33,10 @@ class GoogleBooksServiceTest extends TestCase
                         ],
                     ],
                 ]],
-            ])),
+            ]),
         ]);
 
-        $service = new GoogleBooksService(
-            new Client(['handler' => HandlerStack::create($mock)]),
-            null
-        );
+        $service = new GoogleBooksService(null);
 
         $books = $service->searchBooks('pragmatic programmer');
 
@@ -56,7 +50,7 @@ class GoogleBooksServiceTest extends TestCase
 
     public function test_has_api_key_is_false_when_missing(): void
     {
-        $service = new GoogleBooksService(null, '');
+        $service = new GoogleBooksService('');
 
         $this->assertTrue($service->isConfigured());
         $this->assertFalse($service->hasApiKey());

--- a/tests/Unit/Services/IsbnDbServiceTest.php
+++ b/tests/Unit/Services/IsbnDbServiceTest.php
@@ -6,28 +6,22 @@ namespace Tests\Unit\Services;
 
 use App\Services\BookService;
 use App\Services\IsbnDbService;
-use GuzzleHttp\Client;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Psr7\Response;
+use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
 
 class IsbnDbServiceTest extends TestCase
 {
     public function test_is_configured_returns_false_when_key_is_missing(): void
     {
-        $service = new IsbnDbService(null, '');
+        $service = new IsbnDbService('');
 
         $this->assertFalse($service->isConfigured());
     }
 
     public function test_search_book_maps_response_to_internal_shape(): void
     {
-        $mock = new MockHandler([
-            new Response(200, [
-                'ratelimit' => 'limit=500, remaining=499',
-                'ratelimit-policy' => '500;w=86400',
-            ], json_encode([
+        Http::fake([
+            'api2.isbndb.com/books/*' => Http::response([
                 'total' => 1,
                 'data' => [[
                     'title' => 'Domain-Driven Design',
@@ -41,13 +35,13 @@ class IsbnDbServiceTest extends TestCase
                     'subjects' => ['Software', 'Architecture'],
                     'image' => 'https://example.com/cover.jpg',
                 ]],
-            ])),
+            ], 200, [
+                'ratelimit' => 'limit=500, remaining=499',
+                'ratelimit-policy' => '500;w=86400',
+            ]),
         ]);
 
-        $service = new IsbnDbService(
-            new Client(['handler' => HandlerStack::create($mock), 'base_uri' => 'https://api2.isbndb.com']),
-            'test-key'
-        );
+        $service = new IsbnDbService('test-key');
 
         $book = $service->searchBook('domain driven design');
         $books = $service->searchBooks('domain driven design');
@@ -69,8 +63,8 @@ class IsbnDbServiceTest extends TestCase
 
     public function test_find_by_isbn_reads_book_payload(): void
     {
-        $mock = new MockHandler([
-            new Response(200, [], json_encode([
+        Http::fake([
+            'api2.isbndb.com/book/*' => Http::response([
                 'book' => [
                     'title' => 'Clean Code',
                     'isbn13' => '9780132350884',
@@ -78,13 +72,10 @@ class IsbnDbServiceTest extends TestCase
                     'date_published' => '2008',
                     'subjects' => ['Programming'],
                 ],
-            ])),
+            ]),
         ]);
 
-        $service = new IsbnDbService(
-            new Client(['handler' => HandlerStack::create($mock), 'base_uri' => 'https://api2.isbndb.com']),
-            'test-key'
-        );
+        $service = new IsbnDbService('test-key');
 
         $book = $service->findByIsbn('978-0132350884');
 

--- a/tests/Unit/Services/OpenLibraryServiceTest.php
+++ b/tests/Unit/Services/OpenLibraryServiceTest.php
@@ -5,18 +5,15 @@ declare(strict_types=1);
 namespace Tests\Unit\Services;
 
 use App\Services\OpenLibraryService;
-use GuzzleHttp\Client;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Psr7\Response;
+use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
 
 class OpenLibraryServiceTest extends TestCase
 {
     public function test_search_books_normalizes_docs_payload(): void
     {
-        $mock = new MockHandler([
-            new Response(200, [], json_encode([
+        Http::fake([
+            'openlibrary.org/search.json*' => Http::response([
                 'docs' => [[
                     'key' => '/works/OL123W',
                     'title' => 'Refactoring',
@@ -26,12 +23,10 @@ class OpenLibraryServiceTest extends TestCase
                     'first_publish_year' => 1999,
                     'cover_i' => 54321,
                 ]],
-            ])),
+            ]),
         ]);
 
-        $service = new OpenLibraryService(
-            new Client(['handler' => HandlerStack::create($mock)])
-        );
+        $service = new OpenLibraryService;
 
         $books = $service->searchBooks('refactoring');
 
@@ -45,25 +40,25 @@ class OpenLibraryServiceTest extends TestCase
 
     public function test_find_by_isbn_normalizes_payload(): void
     {
-        $mock = new MockHandler([
-            new Response(200, [], json_encode([
+        Http::fake([
+            'openlibrary.org/isbn/*' => Http::response([
                 'title' => 'Clean Architecture',
                 'authors' => [['name' => 'Robert C. Martin']],
                 'publish_date' => '2017-09-20',
                 'publishers' => ['Prentice Hall'],
                 'covers' => [12345],
-            ])),
+            ]),
         ]);
 
-        $service = new OpenLibraryService(
-            new Client(['handler' => HandlerStack::create($mock)])
-        );
+        $service = new OpenLibraryService;
 
         $book = $service->findByIsbn('9780134494166');
 
         $this->assertNotNull($book);
         $this->assertSame('Clean Architecture', $book['title']);
         $this->assertSame('Robert C. Martin', $book['author']);
-        $this->assertSame('9780134494166', $book['isbn']);
+        $this->assertSame('2017-09-20', $book['publishdate']);
+        $this->assertSame('Prentice Hall', $book['publisher']);
+        $this->assertSame('https://covers.openlibrary.org/b/id/12345-L.jpg', $book['coverurl']);
     }
 }


### PR DESCRIPTION
Migrate direct `GuzzleHttp\Client` instantiation to the Laravel `Http` facade for a consistent HTTP abstraction across the codebase. This follows the same patterns already used in `TmdbClient`, `TraktService`, and `SteamService`.

- Extract duplicated IMDb browser headers to `imdbRequest()` helper in `ImdbScraper` (DRY)
- Remove dead 429 catch branch in `PopulateAniListService` (Http facade never throws on 4xx)
- Remove `?Client` DI constructor parameters (tests now use `Http::fake()`)