### PR TITLE
refactor: replace raw DB queries with Eloquent in models/commands

### DIFF
--- a/app/Console/Commands/DeleteReleases.php
+++ b/app/Console/Commands/DeleteReleases.php
@@ -5,6 +5,13 @@ declare(strict_types=1);
 namespace App\Console\Commands;
 
 use App\Facades\Search;
+use App\Models\ReleaseComment;
+use App\Models\ReleaseFile;
+use App\Models\ReleaseNfo;
+use App\Models\ReleaseSubtitle;
+use App\Models\UsenetGroup;
+use App\Models\UserDownload;
+use App\Models\UsersRelease;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
 
@@ -137,15 +144,15 @@ class DeleteReleases extends Command
                     $this->line("Deleting: {$releaseName}");
 
                     // Delete related data first (to maintain referential integrity)
-                    DB::delete('DELETE FROM user_downloads WHERE releases_id = ?', [$releaseId]);
-                    DB::delete('DELETE FROM users_releases WHERE releases_id = ?', [$releaseId]);
-                    DB::delete('DELETE FROM release_files WHERE releases_id = ?', [$releaseId]);
-                    DB::delete('DELETE FROM release_comments WHERE releases_id = ?', [$releaseId]);
-                    DB::delete('DELETE FROM release_nfos WHERE releases_id = ?', [$releaseId]);
-                    DB::delete('DELETE FROM release_subtitles WHERE releases_id = ?', [$releaseId]);
+                    UserDownload::where('releases_id', $releaseId)->delete();
+                    UsersRelease::where('releases_id', $releaseId)->delete();
+                    ReleaseFile::where('releases_id', $releaseId)->delete();
+                    ReleaseComment::where('releases_id', $releaseId)->delete();
+                    ReleaseNfo::where('releases_id', $releaseId)->delete();
+                    ReleaseSubtitle::where('releases_id', $releaseId)->delete();
 
                     // Delete the main release record
-                    DB::delete('DELETE FROM releases WHERE id = ?', [$releaseId]);
+                    DB::table('releases')->where('id', $releaseId)->delete();
 
                     // Delete from search indexes
                     Search::deleteRelease($releaseId);
@@ -309,14 +316,14 @@ class DeleteReleases extends Command
             },
             'groupname' => match ($modifier) {
                 'equals' => (static function () use ($value) {
-                    $group = DB::select('SELECT id FROM usenet_groups WHERE name = ?', [$value]);
+                    $group = UsenetGroup::where('name', $value)->first(['id']);
 
-                    return ! empty($group) ? " AND groups_id = {$group[0]->id}" : null;
+                    return $group !== null ? " AND groups_id = {$group->id}" : null;
                 })(),
                 'like' => (static function () use ($value) {
-                    $groups = DB::select('SELECT id FROM usenet_groups WHERE name LIKE ?', ['%'.str_replace(' ', '%', $value).'%']);
+                    $groups = UsenetGroup::where('name', 'like', '%'.str_replace(' ', '%', $value).'%')->pluck('id');
 
-                    return ! empty($groups) ? ' AND groups_id IN ('.implode(',', array_column($groups, 'id')).')' : null;
+                    return $groups->isNotEmpty() ? ' AND groups_id IN ('.$groups->implode(',').')' : null;
                 })(),
                 default => null,
             },

--- a/app/Models/TrustedDevice.php
+++ b/app/Models/TrustedDevice.php
@@ -7,7 +7,6 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
 /**
@@ -54,23 +53,16 @@ class TrustedDevice extends Model
         $plainToken = Str::random(64);
         $now = now();
 
-        DB::insert(
-            'insert into trusted_devices (user_id, token_hash, expires_at, ip_address, user_agent, created_at, updated_at) values (?, ?, ?, ?, ?, ?, ?)',
-            [
-                $user->id,
-                self::hashToken($plainToken),
-                $now->copy()->addDays(30)->toDateTimeString(),
-                $ipAddress,
-                $userAgent !== null ? Str::limit($userAgent, 500, '') : null,
-                $now->toDateTimeString(),
-                $now->toDateTimeString(),
-            ]
-        );
-
-        $deviceId = (int) DB::getPdo()->lastInsertId();
-
         /** @var self $device */
-        $device = self::query()->findOrFail($deviceId);
+        $device = self::create([
+            'user_id' => $user->id,
+            'token_hash' => self::hashToken($plainToken),
+            'expires_at' => $now->copy()->addDays(30)->toDateTimeString(),
+            'ip_address' => $ipAddress,
+            'user_agent' => $userAgent !== null ? Str::limit($userAgent, 500, '') : null,
+            'created_at' => $now->toDateTimeString(),
+            'updated_at' => $now->toDateTimeString(),
+        ]);
 
         return ['plain' => $plainToken, 'device' => $device];
     }

--- a/app/Services/ForkingService.php
+++ b/app/Services/ForkingService.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace App\Services;
 
+use App\Models\Collection;
 use App\Models\Settings;
+use App\Models\UsenetGroup;
 use App\Services\Runners\BackfillRunner;
 use App\Services\Runners\BinariesRunner;
 use App\Services\Runners\PostProcessRunner;
 use App\Services\Runners\ReleasesRunner;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Symfony\Component\Process\Process;
 
@@ -278,15 +279,14 @@ class ForkingService
      */
     protected function getReleaseWorkCount(): int
     {
-        $groups = DB::select('SELECT id FROM usenet_groups WHERE (active = 1 OR backfill = 1)');
+        $groups = UsenetGroup::query()
+            ->where(fn ($q) => $q->where('active', 1)->orWhere('backfill', 1))
+            ->get(['id']);
         $count = 0;
 
         foreach ($groups as $group) {
             try {
-                $query = DB::select(
-                    sprintf('SELECT id FROM collections WHERE groups_id = %d LIMIT 1', $group->id)
-                );
-                if (! empty($query)) {
+                if (Collection::where('groups_id', $group->id)->exists()) {
                     $count++;
                 }
             } catch (\PDOException $e) {


### PR DESCRIPTION
Replace raw `DB::select`/`DB::delete` with Eloquent query builder in ForkingService, DeleteReleases command, and TrustedDevice model.