### PR TITLE
refactor: replace raw DB queries with Eloquent in Remover/Regex

### DIFF
--- a/app/Services/RegexService.php
+++ b/app/Services/RegexService.php
@@ -10,7 +10,6 @@ use App\Models\CollectionRegex;
 use App\Models\Release;
 use App\Models\ReleaseNamingRegex;
 use App\Models\UsenetGroup;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 
@@ -58,19 +57,21 @@ class RegexService
      */
     public function addRegex(array $data): bool
     {
-        return (bool) DB::insert(
-            sprintf(
-                'INSERT INTO %s (group_regex, regex, status, description, ordinal%s) VALUES (%s, %s, %d, %s, %d%s)',
-                $this->tableName,
-                ($this->tableName === 'category_regexes' ? ', categories_id' : ''),
-                trim(escapeString($data['group_regex'])),
-                trim(escapeString($data['regex'])),
-                $data['status'],
-                trim(escapeString($data['description'])),
-                $data['ordinal'],
-                ($this->tableName === 'category_regexes' ? (', '.$data['categories_id']) : '')
-            )
-        );
+        $record = [
+            'group_regex' => $data['group_regex'],
+            'regex' => $data['regex'],
+            'status' => $data['status'],
+            'description' => $data['description'],
+            'ordinal' => $data['ordinal'],
+        ];
+
+        if ($this->tableName === 'category_regexes') {
+            $record['categories_id'] = $data['categories_id'];
+        }
+
+        $modelClass = $this->resolveModelClass();
+
+        return (bool) $modelClass::query()->insert($record);
     }
 
     /**
@@ -80,21 +81,21 @@ class RegexService
      */
     public function updateRegex(array $data): bool
     {
-        return (bool) DB::update(
-            sprintf(
-                'UPDATE %s
-                SET group_regex = %s, regex = %s, status = %d, description = %s, ordinal = %d %s
-                WHERE id = %d',
-                $this->tableName,
-                trim(escapeString($data['group_regex'])),
-                trim(escapeString($data['regex'])),
-                $data['status'],
-                trim(escapeString($data['description'])),
-                $data['ordinal'],
-                ($this->tableName === 'category_regexes' ? (', categories_id = '.$data['categories_id']) : ''),
-                $data['id']
-            )
-        );
+        $record = [
+            'group_regex' => $data['group_regex'],
+            'regex' => $data['regex'],
+            'status' => $data['status'],
+            'description' => $data['description'],
+            'ordinal' => $data['ordinal'],
+        ];
+
+        if ($this->tableName === 'category_regexes') {
+            $record['categories_id'] = $data['categories_id'];
+        }
+
+        $modelClass = $this->resolveModelClass();
+
+        return (bool) $modelClass::query()->where('id', $data['id'])->update($record);
     }
 
     /**
@@ -104,7 +105,9 @@ class RegexService
      */
     public function getRegexByID(int $id): array
     {
-        return (array) Arr::first(DB::select(sprintf('SELECT * FROM %s WHERE id = %d LIMIT 1', $this->tableName, $id)));
+        $modelClass = $this->resolveModelClass();
+
+        return (array) $modelClass::query()->where('id', $id)->first();
     }
 
     /**
@@ -156,9 +159,8 @@ class RegexService
      */
     public function deleteRegex(int $id): void
     {
-        DB::transaction(function () use ($id) {
-            DB::delete(sprintf('DELETE FROM %s WHERE id = %d', $this->tableName, $id));
-        }, 3);
+        $modelClass = $this->resolveModelClass();
+        $modelClass::query()->where('id', $id)->delete();
     }
 
     /**
@@ -307,21 +309,28 @@ class RegexService
      */
     protected function _fetchRegex(string $groupName): void
     {
-        // Get all regex from DB which match the current group name. Cache them for 15 minutes. #CACHEDQUERY#
-        $sql = sprintf(
-            'SELECT r.id, r.regex %s FROM %s r WHERE \'%s\' REGEXP r.group_regex AND r.status = 1 ORDER BY r.ordinal ASC, r.group_regex ASC',
-            ($this->tableName === 'category_regexes' ? ', r.categories_id' : ''),
-            $this->tableName,
-            $groupName
-        );
+        $modelClass = $this->resolveModelClass();
+        $select = ['id', 'regex'];
+        if ($this->tableName === 'category_regexes') {
+            $select[] = 'categories_id';
+        }
 
-        $this->_regexCache[$groupName]['regex'] = Cache::get(md5($sql));
+        $cacheKey = md5('regex_'.$this->tableName.'_'.$groupName);
+        $this->_regexCache[$groupName]['regex'] = Cache::get($cacheKey);
         if ($this->_regexCache[$groupName]['regex'] !== null) {
             return;
         }
-        $this->_regexCache[$groupName]['regex'] = DB::select($sql);
+
+        $this->_regexCache[$groupName]['regex'] = $modelClass::query()
+            ->select($select)
+            ->whereRaw('? REGEXP group_regex', [$groupName])
+            ->where('status', 1)
+            ->orderBy('ordinal')
+            ->orderBy('group_regex')
+            ->get();
+
         $expiresAt = now()->addMinutes(config('nntmux.cache_expiry_long'));
-        Cache::put(md5($sql), $this->_regexCache[$groupName]['regex'], $expiresAt);
+        Cache::put($cacheKey, $this->_regexCache[$groupName]['regex'], $expiresAt);
     }
 
     /**
@@ -363,5 +372,14 @@ class RegexService
     protected function _groupQueryString(string $group_regex): string
     {
         return $group_regex ? ('WHERE group_regex LIKE '.escapeString('%'.$group_regex.'%')) : '';
+    }
+
+    private function resolveModelClass(): string
+    {
+        return match ($this->tableName) {
+            'collection_regexes' => CollectionRegex::class,
+            'category_regexes' => CategoryRegex::class,
+            default => ReleaseNamingRegex::class,
+        };
     }
 }

--- a/app/Services/ReleaseRemoverService.php
+++ b/app/Services/ReleaseRemoverService.php
@@ -8,6 +8,7 @@ use App\Enums\BlacklistConstants;
 use App\Facades\Search;
 use App\Models\Category;
 use App\Models\Settings;
+use App\Models\UsenetGroup;
 use App\Services\Nzb\NzbService;
 use App\Services\Releases\ReleaseManagementService;
 use Carbon\Carbon;
@@ -597,9 +598,9 @@ class ReleaseRemoverService
             return '';
         }
 
-        $groupIDs = DB::select(
-            'SELECT id FROM usenet_groups WHERE name REGEXP '.escapeString($groupname)
-        );
+        $groupIDs = UsenetGroup::query()
+            ->whereRaw('name REGEXP ?', [$groupname])
+            ->get(['id']);
 
         if (empty($groupIDs)) {
             return null;
@@ -631,18 +632,13 @@ class ReleaseRemoverService
             ? sprintf('AND status = %d', BlacklistConstants::BLACKLIST_ENABLED)
             : '';
 
-        $regexList = DB::select(sprintf(
-            'SELECT regex, id, groupname, msgcol
-            FROM binaryblacklist
-            WHERE optype = %d
-            AND msgcol IN (%d, %d) %s %s
-            ORDER BY id ASC',
-            BlacklistConstants::OPTYPE_BLACKLIST,
-            BlacklistConstants::BLACKLIST_FIELD_SUBJECT,
-            BlacklistConstants::BLACKLIST_FIELD_FROM,
-            $this->blacklistID,
-            $status
-        ));
+        $regexList = BinaryBlacklist::query()
+            ->where('optype', BlacklistConstants::OPTYPE_BLACKLIST)
+            ->whereIn('msgcol', [BlacklistConstants::BLACKLIST_FIELD_SUBJECT, BlacklistConstants::BLACKLIST_FIELD_FROM])
+            ->when($this->blacklistID !== '', fn ($q) => $q->where('id', $this->blacklistID))
+            ->when($status !== '', fn ($q) => $q->where('status', BlacklistConstants::BLACKLIST_ENABLED))
+            ->orderBy('id')
+            ->get(['regex', 'id', 'groupname', 'msgcol']);
 
         if (empty($regexList)) {
             cli()->error("No regular expressions were selected for blacklist removal. Make sure you have activated REGEXPs in Site Edit and you're specifying a valid ID.", true);
@@ -730,17 +726,12 @@ class ReleaseRemoverService
      */
     protected function removeBlacklistFiles(): bool
     {
-        $allRegex = DB::select(sprintf(
-            'SELECT regex, id, groupname
-            FROM binaryblacklist
-            WHERE status = %d
-            AND optype = %d
-            AND msgcol = %d
-            ORDER BY id ASC',
-            BlacklistConstants::BLACKLIST_ENABLED,
-            BlacklistConstants::OPTYPE_BLACKLIST,
-            BlacklistConstants::BLACKLIST_FIELD_SUBJECT
-        ));
+        $allRegex = BinaryBlacklist::query()
+            ->where('status', BlacklistConstants::BLACKLIST_ENABLED)
+            ->where('optype', BlacklistConstants::OPTYPE_BLACKLIST)
+            ->where('msgcol', BlacklistConstants::BLACKLIST_FIELD_SUBJECT)
+            ->orderBy('id')
+            ->get(['regex', 'id', 'groupname']);
 
         if (empty($allRegex)) {
             return true;
@@ -1103,18 +1094,18 @@ class ReleaseRemoverService
     private function buildGroupClause(string $modifier, string $value): bool|string
     {
         if ($modifier === 'equals') {
-            $group = DB::select('SELECT id FROM usenet_groups WHERE name = '.escapeString($value));
-            if (empty($group)) {
+            $group = UsenetGroup::where('name', $value)->first(['id']);
+            if ($group === null) {
                 $this->error = 'This group was not found in your database: '.$value.PHP_EOL;
 
                 return false;
             }
 
-            return ' AND groups_id = '.$group[0]->id;
+            return ' AND groups_id = '.$group->id;
         }
 
         if ($modifier === 'like') {
-            $groups = DB::select('SELECT id FROM usenet_groups WHERE name '.$this->formatLike($value, 'name'));
+            $groups = UsenetGroup::whereRaw($this->formatLike($value, 'name'))->get(['id']);
             if (empty($groups)) {
                 $this->error = 'No groups were found with this pattern in your database: '.$value.PHP_EOL;
 


### PR DESCRIPTION
Replace raw SQL string building with `escapeString()` by Eloquent query builder, which uses automatic parameter binding and eliminates manual SQL string construction.