### PR TITLE
refactor: replace DB::select COUNT queries with query builder

### DIFF
--- a/app/Services/BookService.php
+++ b/app/Services/BookService.php
@@ -178,13 +178,10 @@ class BookService
         }
 
         // Step 1: Count total distinct books matching filters
-        $countSql = 'SELECT COUNT(DISTINCT boo.id) AS total '
-            .'FROM bookinfo boo '
-            .'INNER JOIN releases r ON boo.id = r.bookinfo_id '
-            .'WHERE '.$baseWhere;
-
-        $totalResult = DB::select($countSql);
-        $totalCount = $totalResult[0]->total ?? 0;
+        $totalCount = DB::table('bookinfo as boo')
+            ->join('releases as r', 'boo.id', '=', 'r.bookinfo_id')
+            ->whereRaw($baseWhere)
+            ->count(DB::raw('DISTINCT boo.id'));
 
         if ($totalCount === 0) {
             return collect();

--- a/app/Services/ConsoleService.php
+++ b/app/Services/ConsoleService.php
@@ -201,13 +201,10 @@ class ConsoleService
         }
 
         // Step 1: Count total distinct consoles matching filters
-        $countSql = 'SELECT COUNT(DISTINCT con.id) AS total '
-            .'FROM consoleinfo con '
-            .'INNER JOIN releases r ON con.id = r.consoleinfo_id '
-            .'WHERE '.$baseWhere;
-
-        $totalResult = DB::select($countSql);
-        $totalCount = $totalResult[0]->total ?? 0;
+        $totalCount = DB::table('consoleinfo as con')
+            ->join('releases as r', 'con.id', '=', 'r.consoleinfo_id')
+            ->whereRaw($baseWhere)
+            ->count(DB::raw('DISTINCT con.id'));
 
         if ($totalCount === 0) {
             return collect();

--- a/app/Services/GamesService.php
+++ b/app/Services/GamesService.php
@@ -258,13 +258,10 @@ class GamesService
         }
 
         // Step 1: Count total distinct games matching filters
-        $countSql = 'SELECT COUNT(DISTINCT gi.id) AS total '
-            .'FROM gamesinfo gi '
-            .'INNER JOIN releases r ON gi.id = r.gamesinfo_id '
-            .'WHERE '.$baseWhere;
-
-        $totalResult = DB::select($countSql);
-        $totalCount = $totalResult[0]->total ?? 0;
+        $totalCount = DB::table('gamesinfo as gi')
+            ->join('releases as r', 'gi.id', '=', 'r.gamesinfo_id')
+            ->whereRaw($baseWhere)
+            ->count(DB::raw('DISTINCT gi.id'));
 
         if ($totalCount === 0) {
             return collect();

--- a/app/Services/MovieBrowseService.php
+++ b/app/Services/MovieBrowseService.php
@@ -115,13 +115,10 @@ class MovieBrowseService
         $totalCount = Cache::get($countCacheKey);
 
         if ($totalCount === null) {
-            $countSql = 'SELECT COUNT(DISTINCT m.imdbid) AS total '
-                .'FROM movieinfo m '
-                .'INNER JOIN releases r ON r.imdbid = m.imdbid '
-                .'WHERE '.$baseWhere;
-
-            $totalResult = DB::select($countSql);
-            $totalCount = $totalResult[0]->total ?? 0;
+            $totalCount = DB::table('movieinfo as m')
+                ->join('releases as r', 'r.imdbid', '=', 'm.imdbid')
+                ->whereRaw($baseWhere)
+                ->count(DB::raw('DISTINCT m.imdbid'));
 
             Cache::put($countCacheKey, $totalCount, now()->addMinutes(30));
         }

--- a/app/Services/MusicService.php
+++ b/app/Services/MusicService.php
@@ -183,13 +183,10 @@ class MusicService
         }
 
         // Step 1: Count total distinct music entities matching filters
-        $countSql = 'SELECT COUNT(DISTINCT m.id) AS total '
-            .'FROM musicinfo m '
-            .'INNER JOIN releases r ON r.musicinfo_id = m.id '
-            .'WHERE '.$baseWhere;
-
-        $totalResult = DB::select($countSql);
-        $totalCount = $totalResult[0]->total ?? 0;
+        $totalCount = DB::table('musicinfo as m')
+            ->join('releases as r', 'r.musicinfo_id', '=', 'm.id')
+            ->whereRaw($baseWhere)
+            ->count(DB::raw('DISTINCT m.id'));
 
         if ($totalCount === 0) {
             return collect();
@@ -462,30 +459,26 @@ class MusicService
      */
     public function processMusicReleases(bool $local = false, string $groupID = '', string $guidChar = ''): void
     {
-        $guidFilter = $guidChar !== '' ? 'AND leftguid LIKE '.DB::getPdo()->quote($guidChar.'%') : '';
-        $groupFilter = $groupID !== '' ? 'AND groups_id = '.(int) $groupID : '';
+        $query = Release::query()
+            ->whereNull('musicinfo_id')
+            ->whereIn('categories_id', [Category::MUSIC_MP3, Category::MUSIC_LOSSLESS, Category::MUSIC_OTHER])
+            ->orderByDesc('postdate')
+            ->limit($this->musicqty)
+            ->select(['searchname', 'id']);
 
-        $res = DB::select(
-            sprintf(
-                '
-                SELECT searchname, id
-                FROM releases
-                WHERE musicinfo_id IS NULL
-                %s
-                %s
-                %s
-                AND categories_id IN (%s, %s, %s)
-                ORDER BY postdate DESC
-                LIMIT %d',
-                $this->renamed,
-                $guidFilter,
-                $groupFilter,
-                Category::MUSIC_MP3,
-                Category::MUSIC_LOSSLESS,
-                Category::MUSIC_OTHER,
-                $this->musicqty
-            )
-        );
+        if ($this->renamed !== '') {
+            $query->whereRaw($this->renamed);
+        }
+
+        if ($guidChar !== '') {
+            $query->where('leftguid', 'like', $guidChar.'%');
+        }
+
+        if ($groupID !== '') {
+            $query->where('groups_id', (int) $groupID);
+        }
+
+        $res = $query->get();
 
         if (! empty($res)) {
             foreach ($res as $arr) {


### PR DESCRIPTION
Replace raw SQL `DB::select` COUNT queries with Laravel's query builder (`DB::table()->join()->whereRaw()->count()`).

Convert one simple SELECT to Eloquent query builder.