### PR TITLE
Fix getCategoryExclusionById() excluding every category for role-only users

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1647,9 +1647,15 @@ final class User extends Authenticatable implements CanResetPasswordContract, Ha
     {
         $user = static::findOrFail($userId);
 
-        $userAllowed = $user->getDirectPermissions()->pluck('name')->toArray();
-        $roleAllowed = $user->getAllPermissions()->pluck('name')->toArray();
-        $allowed = array_intersect($roleAllowed, $userAllowed);
+        // getAllPermissions() already merges permissions granted directly to the
+        // user with permissions granted via their role(s). Intersecting it with
+        // getDirectPermissions() (as this used to do) meant that any user whose
+        // permissions come only from their role -- which is how every seeded
+        // role in RolesAndPermissionsSeeder grants them, including Admin -- ended
+        // up with an empty $allowed array, and therefore every category root
+        // excluded. That silently zeroed out browse/API results for all users
+        // on a fresh install.
+        $allowed = $user->getAllPermissions()->pluck('name')->toArray();
 
         $categoryPermissions = [
             'view console' => 1000,

--- a/tests/Feature/UserExcludedCategoryTest.php
+++ b/tests/Feature/UserExcludedCategoryTest.php
@@ -266,6 +266,29 @@ final class UserExcludedCategoryTest extends TestCase
         $this->assertContains(2070, $exclusions);
     }
 
+    public function test_role_only_permissions_are_not_excluded(): void
+    {
+        // Regression test: RolesAndPermissionsSeeder grants every view permission
+        // via the role only (Role::givePermissionTo), never directly to the user
+        // (User::givePermissionTo). getCategoryExclusionById() must honor
+        // role-granted permissions, not just permissions assigned directly to
+        // the user, or every category ends up excluded on a fresh install.
+        $roleOnlyUser = $this->createTestUser($this->userRole->id);
+        $roleOnlyUser->assignRole($this->userRole);
+        // Deliberately do NOT call $roleOnlyUser->givePermissionTo(...) here.
+
+        $exclusions = User::getCategoryExclusionById($roleOnlyUser->id);
+
+        // The role has every 'view *' permission except 'view other', so only
+        // the 'Other' root category (id 1) should be excluded -- nothing from
+        // the seeded Movies (2000) or TV (5000) root categories.
+        $this->assertNotContains(2030, $exclusions);
+        $this->assertNotContains(2040, $exclusions);
+        $this->assertNotContains(2070, $exclusions);
+        $this->assertNotContains(5030, $exclusions);
+        $this->assertNotContains(5040, $exclusions);
+    }
+
     public function test_clearing_exclusions_works(): void
     {
         // First add exclusions


### PR DESCRIPTION
## Bug

`User::getCategoryExclusionById()` computes which category roots to exclude from browse/search results like this (before this PR):

```php
$userAllowed = $user->getDirectPermissions()->pluck('name')->toArray();
$roleAllowed = $user->getAllPermissions()->pluck('name')->toArray();
$allowed = array_intersect($roleAllowed, $userAllowed);
```

`getAllPermissions()` already includes permissions granted via the user's role(s). Intersecting it with `getDirectPermissions()` (permissions assigned *directly* to the user, bypassing roles) means `$allowed` ends up empty for any user whose permissions come only from their role.

That's every user on a fresh install: `RolesAndPermissionsSeeder` only ever calls `Role::givePermissionTo(...)`, never `User::givePermissionTo(...)`, for every seeded role including Admin.

The practical effect: every category root gets excluded for every user, so the site's browse pages and the Newznab/Torznab API (`t=search`, `t=tvsearch`, etc.) silently return zero results, with no error surfaced anywhere. I hit this setting up a fresh instance and pointing Prowlarr at it — the indexer test kept failing with "Query successful, but no results were returned from your indexer" even after confirming the release existed in the DB and was indexed in Manticore.

## Fix

Use `getAllPermissions()` directly, since it's already the correct merged set (role + direct grants). Removed the redundant `getDirectPermissions()` call and the intersection.

## Testing

Added `test_role_only_permissions_are_not_excluded` to `tests/Feature/UserExcludedCategoryTest.php`, which mirrors the actual seeder setup (permissions granted via role only, nothing granted directly to the user) — this is the scenario the existing tests didn't cover, since the existing `setUp()` grants permissions both ways.

Ran the full test file locally:

```
Tests:    7 passed (17 assertions)
Duration: 13.35s
```

Also verified end-to-end against a real install: reverted a manual direct-permission grant on my admin user, confirmed the Newznab API (`t=search`) returned a test release correctly with the fix in place and no manual permission workaround needed.
